### PR TITLE
Update censor.js

### DIFF
--- a/src/dcommands/censor.js
+++ b/src/dcommands/censor.js
@@ -273,8 +273,8 @@ e.execute = async function (msg, words) {
             }
             if (input.c && input.c.length > 0) {
                 for (const name of input.c) {
-                    if (/(\d+)/.test(input.c[0])) { }
-                    let channel = input.c[0].match(/(\d+)/)[1];
+                    if (/(\d+)/.test(name)) { }
+                    let channel = name.match(/(\d+)/)[1];
                     let guild = bot.channelGuildMap[channel];
                     if (guild == msg.guild.id) channelList.push(channel);
                 }


### PR DESCRIPTION
Updating the --channels part, where a loop was done on the first index only.

However, I don't get why you still have an if without instruction(s) in it. 
Since the `.match()[1]` line should return an empty string if it doesn't match, and the `bot.channelGuildMap[channel]` line should error the returned guild id, it should do the job properly with the next if.