### PR TITLE
Small important fix?

### DIFF
--- a/src/dcommands/editcommand.js
+++ b/src/dcommands/editcommand.js
@@ -95,7 +95,8 @@ class EditcommandCommand extends BaseCommand {
                             commandName = CommandManager.commandList[commands[i].toLowerCase()].name;
                             if (CommandManager.built[commandName].category == bu.CommandType.CAT ||
                                 CommandManager.built[commandName].category == bu.CommandType.MUSIC ||
-                                CommandManager.built[commandName].cannotDisable === true) {
+                                CommandManager.built[commandName].cannotDisable === true ||
+                                commandName === 'editcommand') {
                                 console.debug('no ur not allowed');
                             } else {
                                 console.debug(commandperms[commandName]);

--- a/src/dcommands/editcommand.js
+++ b/src/dcommands/editcommand.js
@@ -6,8 +6,8 @@ class EditcommandCommand extends BaseCommand {
             name: 'editcommand',
             category: bu.CommandType.ADMIN,
             usage: 'editcommand < list \n    | setrole <commandname | "commandname,..."> [role name]... \n    | setperm <commandname | "commandname,..."> [perm number] \n    | toggle <commandname | "commandname,...">',
-            info: 'Changes command-specific usage permissions.\n\n**list** \nShows a list of modified commands (role required/perms required)\n\n**setrole**\nSets the role(s) required in order to use the command(s). Set to blank to disable the custom role requirement.\n\n**setperm** \nSets the permissions required in order to bypass the role requirement (requires `permoverride` in the settings command to be enabled). This has to be a permission number, which can be calculated at <https://discordapi.com/permissions.html>. Set to blank to disable the custom permission options.\n\n**toggle** \nEnables/disables the listed commands'/*,
-            cannotDisable:false*/
+            info: 'Changes command-specific usage permissions.\n\n**list** \nShows a list of modified commands (role required/perms required)\n\n**setrole**\nSets the role(s) required in order to use the command(s). Set to blank to disable the custom role requirement.\n\n**setperm** \nSets the permissions required in order to bypass the role requirement (requires `permoverride` in the settings command to be enabled). This has to be a permission number, which can be calculated at <https://discordapi.com/permissions.html>. Set to blank to disable the custom permission options.\n\n**toggle** \nEnables/disables the listed commands',
+            cannotDisable: true
         });
     }
 
@@ -96,8 +96,7 @@ class EditcommandCommand extends BaseCommand {
                             commandName = CommandManager.commandList[commands[i].toLowerCase()].name;
                             if (CommandManager.built[commandName].category == bu.CommandType.CAT ||
                                 CommandManager.built[commandName].category == bu.CommandType.MUSIC ||
-                                CommandManager.built[commandName].cannotDisable === true ||
-                                commandName === 'editcommand') {
+                                CommandManager.built[commandName].cannotDisable === true) {
                                 console.debug('no ur not allowed');
                             } else {
                                 console.debug(commandperms[commandName]);

--- a/src/dcommands/editcommand.js
+++ b/src/dcommands/editcommand.js
@@ -6,7 +6,8 @@ class EditcommandCommand extends BaseCommand {
             name: 'editcommand',
             category: bu.CommandType.ADMIN,
             usage: 'editcommand < list \n    | setrole <commandname | "commandname,..."> [role name]... \n    | setperm <commandname | "commandname,..."> [perm number] \n    | toggle <commandname | "commandname,...">',
-            info: 'Changes command-specific usage permissions.\n\n**list** \nShows a list of modified commands (role required/perms required)\n\n**setrole**\nSets the role(s) required in order to use the command(s). Set to blank to disable the custom role requirement.\n\n**setperm** \nSets the permissions required in order to bypass the role requirement (requires `permoverride` in the settings command to be enabled). This has to be a permission number, which can be calculated at <https://discordapi.com/permissions.html>. Set to blank to disable the custom permission options.\n\n**toggle** \nEnables/disables the listed commands'
+            info: 'Changes command-specific usage permissions.\n\n**list** \nShows a list of modified commands (role required/perms required)\n\n**setrole**\nSets the role(s) required in order to use the command(s). Set to blank to disable the custom role requirement.\n\n**setperm** \nSets the permissions required in order to bypass the role requirement (requires `permoverride` in the settings command to be enabled). This has to be a permission number, which can be calculated at <https://discordapi.com/permissions.html>. Set to blank to disable the custom permission options.\n\n**toggle** \nEnables/disables the listed commands'/*,
+            cannotDisable:false*/
         });
     }
 

--- a/src/structures/BaseCommand.js
+++ b/src/structures/BaseCommand.js
@@ -8,7 +8,7 @@ class BaseCommand {
         this.aliases = params.aliases || [];
         this.onlyOn = params.onlyOn || undefined;
         this.flags = params.flags || undefined;
-        //this.cannotDisable = params.cannotDisable || false;
+        this.cannotDisable = params.cannotDisable || false;
     }
 
     get isCommand() {

--- a/src/structures/BaseCommand.js
+++ b/src/structures/BaseCommand.js
@@ -8,7 +8,7 @@ class BaseCommand {
         this.aliases = params.aliases || [];
         this.onlyOn = params.onlyOn || undefined;
         this.flags = params.flags || undefined;
-        this.cannotDisable = params.cannotDisable || false;
+        //this.cannotDisable = params.cannotDisable || false;
     }
 
     get isCommand() {

--- a/src/structures/BaseCommand.js
+++ b/src/structures/BaseCommand.js
@@ -7,7 +7,8 @@ class BaseCommand {
         this.info = params.info || '';
         this.aliases = params.aliases || [];
         this.onlyOn = params.onlyOn || undefined;
-        this.flags = params.flags || [];
+        this.flags = params.flags || undefined;
+        //this.cannotDisable = params.cannotDisable || false;
     }
 
     get isCommand() {


### PR DESCRIPTION
Hey there!

This pull requests contains two changes : 
  - a**n ugly** fix to prevent people from toggling off the `editcommand`. I also added a line about `cannotDisable` property in the [BaseCommands.js file](https://github.com/HunteRoi/blargbot/blob/302d1fa4159f9b9f98beb7de1431ca05b2390edc/src/structures/BaseCommand.js) but it's commented as I am not sure it has its place there. It's been repercuted to the `editcommand` file as well (but still as comments). 
Mention me on Discord or answer this thread so I can understand how I can fix issues like this in the future please! 😄 

  - a **possibly breaking** fix for the __**Flags:**__ bit appearing in every `help` message for default commands. "Possibly breaking" in the way that I have no idea if you check everywhere in your code that the `flags` property is undefined or not...