### PR TITLE
Fix tags page being too wide

### DIFF
--- a/src/backend/helpers.js
+++ b/src/backend/helpers.js
@@ -53,13 +53,14 @@ const tagType = {
 };
 
 function mdToHtml(text) {
+    text = text.replace(/([,;/])(?=\S)/g, '$1\u200b');
     return converter.makeHtml(text).replace(/\n/g, '<br>');
 }
 
 function addSubtagReferences(text) {
     return text.replace(/\{([a-z]+)\}/ig, function (match, subtag) {
         return `<a href='#${subtag}'>${match}</a>`;
-    })
+    });
 }
 
 e.init = () => {


### PR DESCRIPTION
Some subtags contain long unbroken chains of text, causing the page to become wider. When the page is too wide, the sidebar doesnt auto hide any more.

Adding zws's to break up words fixes this