### PR TITLE
Bbtag fixes & General improvements

### DIFF
--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -38,25 +38,27 @@ Reason: ${tag.reason}`);
             author: tag.author,
             authorizer: tag.authorizer,
             cooldown: tag.cooldown,
-            modResult: function (context, text) {
-                return text.replace(/<@!?(\d{17,21})>/g, function (match, id) {
-                    let user = msg.guild.members.get(id);
-                    if (user == null)
-                        return '@' + id;
-                    return '@' + user.username + '#' + user.discriminator;
-                }).replace(/<@&(\d{17,21})>/g, function (match, id) {
-                    let role = msg.guild.roles.get(id);
-                    if (role == null)
-                        return '@Unknown Role';
-                    return '@' + role.name;
-                }).replace(/@(everyone|here)/g, (match, type) => '@\u200b' + type);
-            }
+            modResult: e.escapeMentions
         });
         /** @type {string} */
         result.code = tag.content;
         return result;
     }
 };
+
+e.escapeMentions = function (context, text) {
+    return text.replace(/<@!?(\d{17,21})>/g, function (match, id) {
+        let user = context.guild.members.get(id);
+        if (user == null)
+            return '@' + id;
+        return '@' + user.username + '#' + user.discriminator;
+    }).replace(/<@&(\d{17,21})>/g, function (match, id) {
+        let role = context.guild.roles.get(id);
+        if (role == null)
+            return '@Unknown Role';
+        return '@' + role.name;
+    }).replace(/@(everyone|here)/g, (_match, type) => '@\u200b' + type);
+}
 
 e.executeCC = async function (msg, ccName, command) {
     let ccommand = (await bu.getGuild(msg.guild.id)).ccommands[ccName.toLowerCase()];

--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -117,7 +117,7 @@ e.docs = async function (msg, command, topic) {
                     };
                 }).concat({
                     name: 'Other useful topics',
-                    value: '```\nvariables, argTypes, terminology```'
+                    value: '```\nvariables, argTypes, terminology, dynamic```'
                 }).filter(f => f.value.length > 0);
             return await help.sendHelp(msg, { embed }, 'BBTag documentation', true);
         case 'variables':
@@ -227,6 +227,13 @@ e.docs = async function (msg, command, topic) {
                     value: terms[k] + '\n\u200B'
                 };
             });
+            return await help.sendHelp(msg, { embed }, 'BBTag documentation');
+        case 'dynamic':
+            embed.description = 'In bbtag, even the names of subtags can be dynamic. This can be achieved simply by placing subtags before the ' +
+                'first `;` of a subtag. \n e.g. ```{user{get;~action};{userid}}``` If `~action` is set to `name`, then this will run the `username` subtag, ' +
+                'if it is set to `avatar` then it will run the `useravatar` subtag, and so on. Because dynamic subtags are by definition not set in ' +
+                'stone, it is reccommended not to use them, and as such you will recieve warnings when editing/creating a tag/cc which contains a ' +
+                'dynamic subtag. Your tag will function correctly, however some optimisations employed by bbtag will be unable to run on any such tag.'
             return await help.sendHelp(msg, { embed }, 'BBTag documentation');
         default:
             topic = topic.replace(/[\{\}]/g, '');

--- a/src/dcommands/ccommand.js
+++ b/src/dcommands/ccommand.js
@@ -30,6 +30,7 @@ class CcommandCommand extends BaseCommand {
                 + '  **cc import <tag> [name]** - imports a tag as a custom command, retaining all data such as author variables\n'
                 + '  **cc help** - shows this message\n'
                 + '  **cc sethelp** <name> [help text] - set the help message for a custom command\n'
+                + '  **cc setlang** <name> [lang] - set the language to use when returning the raw text of your cc\n'
                 + '  **cc debug <name>** - executes the specified custom command and sends a file containing all the debug information\n'
                 + '  **cc docs** [topic] - view help docuentation for BBTag, specific to ccommands\n'
                 + '  \nFor more information about BBTag, visit https://blargbot.xyz/tags'
@@ -39,9 +40,7 @@ class CcommandCommand extends BaseCommand {
     async execute(msg, words, text) {
         console.debug('Text:', text);
         if (words[1]) {
-            let tag;
-            let content;
-            let title;
+            let tag, content, title, lang;
             switch (words[1].toLowerCase()) {
                 case 'cooldown':
                     title = filterTitle(words[2]);
@@ -110,7 +109,8 @@ class CcommandCommand extends BaseCommand {
                             author: msg.author.id,
                             authorizer: msg.author.id
                         });
-                        bu.send(msg, `✅ Custom command \`${title}\` created. ✅`);
+                        result = bbtag.addAnalysis(content, `✅ Custom command \`${title}\` created. ✅`);
+                        bu.send(msg, result);
                     } else {
                         bu.send(msg, 'Not enough arguments! Do `help ccommand` for more information.');
                     }
@@ -194,9 +194,11 @@ class CcommandCommand extends BaseCommand {
                         await bu.ccommand.set(msg.channel.guild.id, title, {
                             content,
                             author: msg.author.id,
-                            authorizer: (tag ? tag.authorizer : undefined) || msg.author.id
+                            authorizer: (tag ? tag.authorizer : undefined) || msg.author.id,
+                            lang: tag.lang
                         });
-                        bu.send(msg, `✅ Custom command \`${title}\` edited. ✅`);
+                        result = bbtag.addAnalysis(content, `✅ Custom command \`${title}\` edited. ✅`);
+                        bu.send(msg, result);
                     } else {
                         bu.send(msg, 'Not enough arguments! Do `help ccommand` for more information.');
                     }
@@ -215,7 +217,8 @@ class CcommandCommand extends BaseCommand {
                             author: msg.author.id,
                             authorizer: (tag ? tag.authorizer : undefined) || msg.author.id
                         });
-                        bu.send(msg, `✅ Custom command \`${title}\` set. ✅`);
+                        result = bbtag.addAnalysis(content, `✅ Custom command \`${title}\` set. ✅`);
+                        bu.send(msg, result);
                     } else {
                         bu.send(msg, 'Not enough arguments! Do `help ccommand` for more information.');
                     }
@@ -298,14 +301,17 @@ class CcommandCommand extends BaseCommand {
                             bu.send(msg, `That ccommand is imported. The raw source is available from the \`${tag.alias}\` tag.`);
                             break;
                         }
-                        let lang = '';
-                        if (tag.content) tag = tag.content;
-                        if (/\{lang;.*?}/i.test(tag)) {
-                            lang = tag.match(/\{lang;(.*?)}/i)[1];
+                        lang = tag.lang || '';
+                        if (typeof tag === 'string') tag = { content: tag };
+                        content = `The raw code for ${title} is\`\`\`${lang}\n${tag.content}\n\`\`\``;
+                        if (content.length > 2000 || tag.match(/`{3}/g)) {
+                            bu.send(msg, `The raw code for ${title} is attached`, {
+                                name: title + '.bbtag',
+                                file: tag.content
+                            });
+                        } else {
+                            bu.send(msg, content);
                         }
-                        content = tag.replace(/`/g, '`\u200B');
-
-                        bu.send(msg, `The raw code for ${title} is\`\`\`${lang}\n${content}\n\`\`\``);
                     } else {
                         bu.send(msg, 'Not enough arguments! Do `help ccommand` for more information.');
                     }
@@ -325,7 +331,7 @@ class CcommandCommand extends BaseCommand {
                             bu.send(msg, 'That ccommand doesn\'t exist!');
                             break;
                         }
-                        content = bu.splitInput(text, true).slice(3).join(' ');
+                        content = words.slice(3).join(' ');
                         var message = "";
                         if (await bu.ccommand.sethelp(msg.channel.guild.id, title, content)) {
                             message = `✅ Help for custom command \`${title}\` set. ✅`;
@@ -390,6 +396,22 @@ class CcommandCommand extends BaseCommand {
                     let result = await bbtag.executeCC(msg, filterTitle(words[2]), words.slice(3));
                     await bu.send(result.context.msg, undefined, bbtag.generateDebug(result.code, result.context));
 
+                    break;
+                case 'setlang':
+                    if (words.length == 3 || words.length == 4) {
+                        title = filterTitle(words[2]);
+                        tag = await bu.ccommand.get(msg.channel.guild.id, title);
+                        if (!tag) {
+                            bu.send(msg, 'That ccommand doesn\'t exist!');
+                            break;
+                        }
+                        await bu.ccommand.setlang(msg.channel.guild.id, title, words[3]);
+                        bu.send(msg, `✅ Lang for custom command \`${title}\` set. ✅`);
+                    } else if (words.length > 4) {
+                        bu.send(msg, 'Too many arguments! Do `help ccommand` for more information.');
+                    } else {
+                        bu.send(msg, 'Not enough arguments! Do `help ccommand` for more information.');
+                    }
                     break;
                 default:
                     bu.send(msg, 'Improper usage. Do \`help ccommand\` for more details.');

--- a/src/dcommands/tag.js
+++ b/src/dcommands/tag.js
@@ -103,6 +103,11 @@ const subcommands = [
         name: 'flag',
         args: '<tag> | <add|remove> <name> <flags>',
         desc: 'Retrieves or sets the flags for a tag.'
+    },
+    {
+        name: 'setlang',
+        args: '<tag> <lang>',
+        desc: 'Sets the language to use when returning the raw text of your tag'
     }
 ];
 const tagNameMsg = 'Enter the name of the tag:';
@@ -191,7 +196,7 @@ class TagCommand extends BaseCommand {
 
     async execute(msg, words, text) {
         let page = 0;
-        let title, content, tag, author, authorizer, originalTagList;
+        let title, content, tag, author, authorizer, originalTagList, lang, result;
         if (words[1]) {
             switch (words[1].toLowerCase()) {
                 case 'cooldown':
@@ -252,7 +257,8 @@ class TagCommand extends BaseCommand {
                         lastmodified: r.epochTime(moment() / 1000),
                         uses: 0
                     }).run();
-                    bu.send(msg, `✅ Tag \`${title}\` created. ✅`);
+                    result = bbtag.addAnalysis(content, `✅ Tag \`${title}\` created. ✅`);
+                    bu.send(msg, result);
                     logChange('Create', msg, {
                         tag: title,
                         content: content
@@ -329,7 +335,8 @@ class TagCommand extends BaseCommand {
                         content: content,
                         lastmodified: r.epochTime(moment() / 1000)
                     }).run();
-                    bu.send(msg, `✅ Tag \`${title}\` edited. ✅`);
+                    result = bbtag.addAnalysis(content, `✅ Tag \`${title}\` edited. ✅`);
+                    bu.send(msg, result);
                     logChange('Edit', msg, {
                         tag: title,
                         content: content
@@ -369,9 +376,11 @@ class TagCommand extends BaseCommand {
                         content: content,
                         lastmodified: r.epochTime(moment() / 1000),
                         uses: tag ? tag.uses : 0,
-                        flags: []
+                        flags: [],
+                        lang: tag.lang
                     }).run();
-                    bu.send(msg, `✅ Tag \`${title}\` ${tag ? 'edited' : 'created'}. ✅`);
+                    result = bbtag.addAnalysis(content, `✅ Tag \`${title}\` set. ✅`);
+                    bu.send(msg, result);
                     logChange(tag ? 'Edit' : 'Create', msg, {
                         tag: title,
                         content: content
@@ -503,15 +512,17 @@ ${command[0].desc}`);
                         bu.send(msg, `❌ That tag has been permanently deleted! ❌`);
                         break;
                     }
-                    let lang = '';
-                    if (/\{lang;.*?}/i.test(tag.content)) {
-                        lang = tag.content.match(/\{lang;(.*?)}/i)[1];
+                    lang = tag.lang || '';
+                    content = `The raw code for ${words[2]} is:\n\`\`\`${lang}\n${tag.content}\n\`\`\``;
+                    if (content.length > 2000 || tag.content.match(/`{3}/)) {
+                        bu.send(msg, `The raw code for ${title} is attached`, {
+                            name: title + '.bbtag',
+                            file: tag.content
+                        });
+                    } else {
+                        bu.send(msg, content);
                     }
-                    content = tag.content.replace(/`/g, '`\u200B');
-                    bu.send(msg, `The code for ${words[2]} is:
-\`\`\`${lang}
-${content}
-\`\`\``);
+
                     break;
                 case 'author':
                     if (words[2]) title = words[2];
@@ -645,7 +656,7 @@ It has been favourited **${count || 0} time${(count || 0) == 1 ? '' : 's'}**!`;
                     }
                     break;
                 case 'debug':
-                    let result = await bbtag.executeTag(msg, filterTitle(words[2]), words.slice(3));
+                    result = await bbtag.executeTag(msg, filterTitle(words[2]), words.slice(3));
                     let dmChannel = await result.context.user.getDMChannel();
 
                     if (dmChannel == null)
@@ -775,6 +786,22 @@ ${Object.keys(user.favourites).join(', ')}
                     break;
                 case 'docs':
                     bbtag.docs(msg, words[0], words.slice(2).join(' '));
+                    break;
+                case 'setlang':
+                    if (words.length == 3 || words.length == 4) {
+                        title = filterTitle(words[2]);
+                        tag = await r.table('tag').get(words[2]).run();
+                        if (!tag) {
+                            bu.send(msg, 'That tag doesn\'t exist!');
+                            break;
+                        }
+                        await r.table('tag').get(title).update({ lang: words[3] }).run();
+                        bu.send(msg, `✅ Lang for tag \`${title}\` set. ✅`);
+                    } else if (words.length > 4) {
+                        bu.send(msg, 'Too many arguments! Do `help tag` for more information.');
+                    } else {
+                        bu.send(msg, 'Not enough arguments! Do `help tag` for more information.');
+                    }
                     break;
                 default:
                     await bbtag.executeTag(msg, filterTitle(words[1]), words.slice(2));

--- a/src/dcommands/tag.js
+++ b/src/dcommands/tag.js
@@ -650,7 +650,7 @@ It has been favourited **${count || 0} time${(count || 0) == 1 ? '' : 's'}**!`;
                                     '```',
                                     `${text}`
                                 ];
-                                return lines.join('\n');
+                                return bbtag.escapeMentions(context, lines.join('\n'));
                             }, attach: debug ? bbtag.generateDebug(args.join(' ')) : null
                         });
                     }
@@ -890,7 +890,6 @@ ${Object.keys(user.favourites).join(', ')}
         }
     };
 }
-
 
 function escapeRegex(str) {
     return (str + '').replace(/[.?*+^$[\]\\(){}|-]/g, "\\$&");

--- a/src/dcommands/timers.js
+++ b/src/dcommands/timers.js
@@ -71,24 +71,31 @@ class TimersCommand extends BaseCommand {
                     let getUserString = user => typeof user === 'object' ? `${user.username}#${user.discriminator}` : user;
                     let records = [];
                     for (const timer of selected) {
-                        console.debug(timer);
                         let id = timer.id.substring(0, 5);
                         let type = timer.type;
                         let user = getUserString(bot.users.get(timer.user) || timer.user);
                         let elapsed = timer.starttime.humanize();
                         let remain = moment.duration(now.diff(timer.endtime)).humanize();
-                        let content = timer.content || '';
+                        let content = Array.from(timer.content || '');
                         if (content.length > 40)
-                            content = content.substring(0, 37) + '...';
-                        content = content.replace(/[\n\t\r]/g, '');
-                        records.push([id, elapsed, remain, user, type, content]);
+                            content = content.slice(0, 37).concat(['...']);
+                        content = content.join('').replace(/[\n\t\r]/g, '');
+                        records.push([id, elapsed, remain, Array.from(user), type, content]);
                     }
                     let headers = ['Id', 'Elapsed', 'Remain', 'User', 'Type', 'Content'];
                     let colSizes = records.concat([headers]).reduce((p, c) => {
                         c.forEach((v, i) => p[i] = Math.max(p[i], v.length));
                         return p;
                     }, records[0].map(() => 0));
-                    let mapLine = l => l.map((v, i) => v.padEnd(colSizes[i])).join(' | ');
+                    console.debug(colSizes);
+                    let mapLine = l =>
+                        l.map((v, i) => {
+                            if (typeof v === 'string')
+                                return v.padEnd(colSizes[i]);
+                            for (let j = v.length; j < colSizes[i]; j++)
+                                v.push(' ');
+                            return v.join('');
+                        }).join(' | ');
                     message += mapLine(headers) + '\n';
                     message += ''.padEnd(colSizes.reduce((p, c) => p + c, 0) + (colSizes.length - 1) * 3, '-') + '\n';
                     message += records.map(mapLine).join('\n');

--- a/src/structures/bbtag/Context.js
+++ b/src/structures/bbtag/Context.js
@@ -98,8 +98,6 @@ class Context {
             overrides: {},
             cache: {}
         };
-
-        console.debug(this);
     }
 
     ownsMessage(messageId) {

--- a/src/structures/bbtag/Engine.js
+++ b/src/structures/bbtag/Engine.js
@@ -190,7 +190,7 @@ async function runTag(content, context) {
     if (result != null && context.state.replace != null)
         result = result.replace(context.state.replace.regex, context.state.replace.with);
 
-    result = (config.modResult || ((c, r) => r))(context, result);
+    result = (config.modResult || ((_, r) => r))(context, result);
 
     if (typeof result == 'object')
         result = await result;

--- a/src/tags/lang.js
+++ b/src/tags/lang.js
@@ -12,6 +12,7 @@ const Builder = require('../structures/TagBuilder');
 module.exports =
     Builder.AutoTag('lang')
         .withArgs(a => a.require('language'))
+        .isDeprecated(true)
         .withDesc('Specifies which `language` should be used when viewing the raw of this tag')
         .withExample(
             'This will be displayed with js! {lang;js}.',

--- a/src/utils/database.js
+++ b/src/utils/database.js
@@ -137,7 +137,6 @@ bu.ccommand = {
 
         if (!storedGuild || !storedGuild.ccommands[key.toLowerCase()]) return false;
         storedGuild.ccommands[key.toLowerCase()].help = help;
-        console.debug(storedGuild.ccommands[key.toLowerCase()]);
         r.table('guild').get(guildid).replace(storedGuild).run();
         return true;
     },
@@ -146,6 +145,20 @@ bu.ccommand = {
 
         if (!storedGuild || !storedGuild.ccommands[key.toLowerCase()]) return undefined;
         return storedGuild.ccommands[key.toLowerCase()].help;
+    },
+    setlang: async function (guildid, key, lang) {
+        let storedGuild = await bu.getGuild(guildid);
+
+        if (!storedGuild || !storedGuild.ccommands[key.toLowerCase()]) return false;
+        storedGuild.ccommands[key.toLowerCase()].lang = lang;
+        r.table('guild').get(guildid).replace(storedGuild).run();
+        return true;
+    },
+    getlang: async function (guildid, key) {
+        let storedGuild = await bu.getGuild(guildid);
+
+        if (!storedGuild || !storedGuild.ccommands[key.toLowerCase()]) return undefined;
+        return storedGuild.ccommands[key.toLowerCase()].lang;
     }
 };
 


### PR DESCRIPTION
 - [x] Remove `{lang}`
   - Replaced by `b!t/cc setlang <tag> <lang>`
 - [x] Improve `b!t/cc raw <name>`
   - Natively sends an embed if the content contains "/`{3}/" or is > 2000 characters
 - [x] Mentions not being escaped
   - `b!t test` wasnt escaping mentions
 - [x] Fix `b!timers` formatting issue with unicode names
   - Now using `Array.from` to work out the length of usernames
 - [x] Add analysis for tags & cc's
   - When using `b!t/cc create/edit/set` if there are any unknown or unnamed subtags then errors will be shown. If there are any dynamic subtags or deprecated subtags then warnings will be shown
 - [x] Add dynamic subtag definition to `b!t/cc docs`