### PR TITLE
Rework subtag limits

### DIFF
--- a/src/backend/helpers.js
+++ b/src/backend/helpers.js
@@ -11,6 +11,7 @@ const showdown = require('showdown');
 const hbs = require('hbs');
 const argumentFactory = require('../structures/ArgumentFactory');
 const path = require('path');
+const bbtag = require('../core/bbtag');
 
 const converter = new showdown.Converter({ backslashEscapesHTMLTags: true });
 let e = module.exports = {};
@@ -56,7 +57,12 @@ const tagType = {
 
 function mdToHtml(text) {
     text = text.replace(/([,;/])(?=\S)/g, '$1\u200b');
-    return converter.makeHtml(text).replace(/\n/g, '<br>');
+    let result = converter.makeHtml(text).replace(/\n/g, '<br>');
+
+    // if (result.startsWith('<p>'))
+    //     result = result.substr(3, result.length - 7);
+
+    return result;
 }
 
 function addSubtagReferences(text) {
@@ -200,17 +206,44 @@ e.init = () => {
             let aliasBlock = subtag.aliases ? ` <small>(${subtag.aliases.join(', ')})</small>` : '';
             toReturn += `<h4 id='${keys[i]}'>${keys[i]}${aliasBlock}</h4>`;
             if (subtag.deprecated) {
-                toReturn += `<p>This tag is deprecated. Avoid using it, as it will eventually become unsupported. ${
+                toReturn += `<div class="tagdeprecated"><p>This tag is deprecated. Avoid using it, as it will eventually become unsupported. ${
                     typeof subtag.deprecated === 'string' ? 'Please use ' + subtag.deprecated + ' instead' : ''
-                    }</p>`;
+                    }</p></div>`;
             }
-            if (lastType != 1) {
-                console.log(argumentFactory.toString(subtag.args));
-                console.log(mdToHtml(argumentFactory.toString(subtag.args)));
-                toReturn += mdToHtml('Arguments: `' + argumentFactory.toString(subtag.args) + '`');
+            if (subtag.args) {
+                toReturn += `<div class="tagargs">${mdToHtml('`' + argumentFactory.toString(subtag.args) + '`')}</div>`;
             }
-            if (subtag.array) toReturn += `<p>Array compatible</p>`;
-            toReturn += `<p>${addSubtagReferences(mdToHtml(subtag.desc))}</p>`;
+            if (subtag.array) toReturn += `<div class="tagarray"><p>Array compatible</p></div>`;
+            toReturn += `<div class="tagdescription">${addSubtagReferences(mdToHtml(subtag.desc))}</div><div class="taglimits">`;
+
+            for (const key of Object.keys(bbtag.limits)) {
+                let limit = bbtag.limits[key][subtag.name];
+                if (limit !== undefined) {
+                    let limitText = '';
+                    if (limit.disabled) {
+                        limitText += '- Disabled<br />';
+                    } else {
+                        if (limit.staff) {
+                            limitText += '- Author must be staff<br />';
+                        }
+                        if (limit.count !== undefined) {
+                            limitText += `- Maximum ${limit.count} uses<br />`;
+                        }
+                        if (limit.loops !== undefined) {
+                            limitText += `- Maximum ${limit.loops} loops<br />`;
+                        }
+                    }
+                    if (limitText) {
+                        toReturn += `<div class="taglimit"><h5>Limits for ${
+                            bbtag.limits[key]._name
+                            }s</h5><blockquote>${
+                            limitText.substr(0, limitText.length - 6)
+                            }</blockquote></div>`;
+                    }
+                }
+            }
+
+            toReturn += '</div><div class="tagexamples">';
 
             if (subtag.exampleCode)
                 toReturn += `<h5>Example Code:</h5><blockquote>${mdToHtml(subtag.exampleCode)}</blockquote>`;
@@ -218,7 +251,7 @@ e.init = () => {
                 toReturn += `<h5>Example Input:</h5><blockquote>${mdToHtml(subtag.exampleIn)}</blockquote>`;
             if (subtag.exampleOut)
                 toReturn += `<h5>Example Output:</h5><blockquote>${mdToHtml(subtag.exampleOut)}</blockquote>`;
-            toReturn += ' </div></div>';
+            toReturn += ' </div></div></div>';
         }
         toReturn += `
                    

--- a/src/backend/public/css/main.css
+++ b/src/backend/public/css/main.css
@@ -259,6 +259,10 @@ ul.collapsible.collapsible-accordion .collapsible-header {
     margin-top: 10px;
 }
 
+.taglimits:empty {
+    margin: 0;
+}
+
 .taglimit {
     padding: 0 15px;
 }

--- a/src/backend/public/css/main.css
+++ b/src/backend/public/css/main.css
@@ -249,3 +249,20 @@ main {
 ul.collapsible.collapsible-accordion .collapsible-header {
     padding: 0 32px;
 }
+
+.tagargs {
+    margin: 10px 0;
+}
+
+.taglimits {
+    display: flex;
+    margin-top: 10px;
+}
+
+.taglimit {
+    padding: 0 15px;
+}
+
+.taglimit:first-child {
+    padding: 0 15px 0 0;
+}

--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -250,8 +250,6 @@ async function docs(msg, command, topic) {
                     ? ' and has been replaced by `{' + tag.deprecated + '}`'
                     : '') + '**\n';
             }
-            if (tag.staff) embed.description += '**This subtag may only be used by staff members**\n';
-            if (tag.category == bu.TagType.CCOMMAND) embed.description += '**This subtag may only be used within custom commands**\n';
             embed.description += '```\n{' + [tag.name, argFactory.toString(tag.args, argsOptions)].filter(t => t.length > 0).join(';') + '}```';
             embed.description += tag.desc + '\n';
 
@@ -321,25 +319,6 @@ function generateDebug(code, context) {
             'Variables:\n' + (variables.length > 0 ? variables.join('\n') : 'No variables') + '\n\n' +
             'Subtag Breakdown:\n' + subtags.join('\n\n')
     };
-};
-
-const limits = {
-    tag: {
-        edit: { count: 10 },
-        delete: { count: 11 },
-        waitmessage: { count: 5 },
-        waitreact: { count: 20 }
-    },
-    ccommand: {
-        send: { count: 10 },
-        edit: { count: 10 },
-        delete: { count: 11 },
-        waitmessage: { count: 10 },
-        waitreact: { count: 20 }
-    },
-    autoresponse: {
-        // ToDo: add limits here
-    }
 };
 
 function analyze(code) {
@@ -436,6 +415,87 @@ function viewErrors(...errors) {
     return result;
 }
 
+const limits = {
+    /** @type {subtagLimit} */
+    tag: {
+        _name: 'tag',
+        ban: { disabled: true },
+        unban: { disabled: true },
+
+        kick: { disabled: true },
+
+        modlog: { disabled: true },
+        pardon: { disabled: true },
+        warn: { disabled: true },
+        warnings: { disabled: true },
+        reason: { disabled: true },
+
+        roleadd: { disabled: true },
+        rolecreate: { disabled: true },
+        roledelete: { disabled: true },
+        rolemention: { disabled: true },
+        roleremove: { disabled: true },
+        rolesetmentionable: { disabled: true },
+
+        dm: { disabled: true },
+        send: { disabled: true },
+        edit: { count: 10 },
+        delete: { count: 11 },
+
+        timer: { disabled: true },
+
+        usersetnick: { disabled: true },
+
+        waitmessage: { count: 5 },
+        waitreact: { count: 20 },
+
+        for: { loops: 1500 },
+        foreach: { loops: 3000 },
+        get repeat() { return this.for; }
+    },
+    ccommand: {
+        _name: 'custom command',
+
+        ban: { staff: true },
+        unban: { staff: true },
+
+        kick: { staff: true },
+
+        modlog: { staff: true },
+        pardon: { staff: true },
+        warn: { staff: true },
+        warnings: { staff: true },
+        reason: { staff: true },
+
+        roleadd: { staff: true },
+        rolecreate: { staff: true },
+        roledelete: { staff: true },
+        rolemention: { staff: true },
+        roleremove: { staff: true },
+        rolesetmentionable: { staff: true },
+
+        dm: { staff: true },
+        send: { staff: true, count: 10 },
+        edit: { count: 10 },
+        delete: { count: 11 },
+
+        timer: { staff: true },
+
+        usersetnick: { staff: true },
+
+        waitmessage: { count: 10 },
+        waitreact: { count: 20 },
+
+        for: { loops: 1500 },
+        foreach: { loops: 3000 },
+        get repeat() { return this.for; }
+    },
+    autoresponse: {
+        _name: 'autoresponse'
+        // ToDo: add limits here
+    }
+};
+
 module.exports = {
     executeTag,
     executeCC,
@@ -445,4 +505,4 @@ module.exports = {
     limits,
     analyze,
     addAnalysis
-}
+};

--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -240,7 +240,6 @@ async function docs(msg, command, topic) {
             let tag = TagManager.get(topic.toLowerCase());
             if (tag == null)
                 break;
-            let category = bu.TagType.properties[tag.category];
             embed.title += ' - ' + tag.name[0].toUpperCase() + tag.name.substring(1);
 
             embed.description = '';
@@ -262,6 +261,34 @@ async function docs(msg, command, topic) {
                 });
             else
                 embed.description += '\u200B';
+
+            for (const key of Object.keys(limits)) {
+                let limit = limits[key][tag.name];
+                if (limit !== undefined) {
+                    let limitText = '';
+                    if (limit.disabled) {
+                        limitText += '- Disabled\n';
+                    } else {
+                        if (limit.staff) {
+                            limitText += '- Author must be staff\n';
+                        }
+                        if (limit.count !== undefined) {
+                            limitText += `- Maximum ${limit.count} uses\n`;
+                        }
+                        if (limit.loops !== undefined) {
+                            limitText += `- Maximum ${limit.loops} loops\n`;
+                        }
+                    }
+                    if (limitText) {
+                        embed.fields.push({
+                            name: `Limits for ${limits[key]._name}s`,
+                            value: limitText,
+                            inline: true
+                        });
+                    }
+                }
+            }
+
             if (tag.exampleCode)
                 embed.fields.push({
                     name: 'Example code',

--- a/src/core/discord.js
+++ b/src/core/discord.js
@@ -108,7 +108,7 @@ class DiscordClient extends Client {
             ' | Simple: ' + tags.filter(t => t == bu.TagType.SIMPLE).length +
             ' | Complex: ' + tags.filter(t => t == bu.TagType.COMPLEX).length +
             ' | Array: ' + tags.filter(t => t == bu.TagType.ARRAY).length +
-            ' | CCommand: ' + tags.filter(t => t == bu.TagType.CCOMMAND).length);
+            ' | CCommand: ' + tags.filter(t => t == bu.TagType.BOT).length);
 
         const CommandManagerClass = require('./CommandManager.js');
         global.CommandManager = new CommandManagerClass();

--- a/src/core/discord.js
+++ b/src/core/discord.js
@@ -45,7 +45,7 @@ const loggr = new CatLoggr({
 
 loggr.addArgHook(({ arg }) => {
     if (arg instanceof seqErrors.BaseError && Array.isArray(arg.errors)) {
-        let text = [arg.stack]
+        let text = [arg.stack];
         for (const err of arg.errors) {
             text.push(`\n - ${err.message}\n   - ${err.path} ${err.validatorKey} ${err.value}`);
         }
@@ -125,7 +125,7 @@ class DiscordClient extends Client {
             }).catch(err => {
                 // failed to send message to master
             });
-        })
+        });
     }
 
     async eval(msg, text, send = true) {

--- a/src/dcommands/ccommand.js
+++ b/src/dcommands/ccommand.js
@@ -381,6 +381,7 @@ class CcommandCommand extends BaseCommand {
                     if (args.length > 0) {
                         await bbEngine.runTag({
                             msg,
+                            limits: bbtag.limits.ccommand,
                             tagContent: args.join(' '),
                             input: '',
                             tagName: 'test',

--- a/src/dcommands/farewell.js
+++ b/src/dcommands/farewell.js
@@ -53,6 +53,7 @@ class FarewellCommand extends BaseCommand {
         }
         await bbEngine.runTag({
             msg,
+            limits: bbtag.limits.ccommand,
             tagContent: farewell.content,
             input: '',
             isCC: true,

--- a/src/dcommands/greet.js
+++ b/src/dcommands/greet.js
@@ -52,6 +52,7 @@ class GreetCommand extends BaseCommand {
         }
         await bbEngine.runTag({
             msg,
+            limits: bbtag.limits.ccommand,
             tagContent: greeting.content,
             input: '',
             isCC: true,

--- a/src/dcommands/tag.js
+++ b/src/dcommands/tag.js
@@ -631,6 +631,7 @@ It has been favourited **${count || 0} time${(count || 0) == 1 ? '' : 's'}**!`;
                             await r.table('tag').get('test').replace(systemTag('test')).run();
                         await bbEngine.runTag({
                             msg,
+                            limits: bbtag.limits.tag,
                             tagContent: args.join(' '),
                             input: '',
                             tagName: 'test',
@@ -868,8 +869,6 @@ ${Object.keys(user.favourites).join(', ')}
         context.state.embed = null;
         context.state.reactions = [];
 
-        console.debug(context.state);
-
         if (args.version == 2) {
             context.state.count.loop = context.state.repeats;
             context.state.count.foreach = context.state.foreach;
@@ -880,7 +879,7 @@ ${Object.keys(user.favourites).join(', ')}
             delete context.state.foreach;
         }
 
-        console.debug(context.state);
+        // TODO: Add migration for new limit system
 
         try {
             await bbEngine.runTag(content, context);

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -30,6 +30,7 @@ bot.on('guildMemberAdd', async function (guild, member) {
                 member: member,
                 guild: guild
             },
+            limits: bbtag.limits.ccommand,
             tagContent: ccommandContent,
             input: '',
             isCC: true,

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -29,6 +29,7 @@ bot.on('guildMemberRemove', async function (guild, member) {
                 member: member,
                 guild: guild
             },
+            limits: bbtag.limits.ccommand,
             tagContent: ccommandContent,
             input: '',
             isCC: true,

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -9,6 +9,7 @@
 
 const moment = require('moment-timezone');
 const bbEngine = require('../structures/bbtag/Engine');
+const bbtag = require('../core/bbtag');
 const Timer = require('../structures/Timer');
 const util = require('util');
 const request = require('request');
@@ -198,6 +199,7 @@ var handleDiscordCommand = async function (channel, user, text, msg) {
             }
             await bbEngine.runTag({
                 msg,
+                limits: bbtag.limits.ccommand,
                 tagContent: ccommandContent,
                 flags: val.flags,
                 input: command,
@@ -369,6 +371,7 @@ bu.handleCensor = async function handleCensor(msg, storedGuild) {
                     }
                     await bbEngine.runTag({
                         msg,
+                        limits: bbtag.limits.ccommand,
                         tagContent: content,
                         input: msg.content,
                         isCC: true,
@@ -410,6 +413,7 @@ async function handleRoleme(msg, storedGuild) {
                         console.verbose(roleme[i].output);
                         await bbEngine.runTag({
                             msg,
+                            limits: bbtag.limits.ccommand,
                             tagContent: roleme[i].output || 'Your roles have been edited!',
                             input: '',
                             isCC: true,
@@ -435,6 +439,7 @@ async function handleAutoresponse(msg, storedGuild, everything = false) {
         if (everything && ars.everything) {
             await bbEngine.runTag({
                 msg,
+                limits: bbtag.limits.autoresponse,
                 tagContent: storedGuild.ccommands[ars.everything.executes].content,
                 author: storedGuild.ccommands[ars.everything.executes].author,
                 input: msg.content,
@@ -467,6 +472,7 @@ async function handleAutoresponse(msg, storedGuild, everything = false) {
                 if (cont && storedGuild.ccommands[ar.executes]) {
                     await bbEngine.runTag({
                         msg,
+                        limits: bbtag.limits.autoresponse,
                         tagContent: storedGuild.ccommands[ar.executes].content,
                         author: storedGuild.ccommands[ar.executes].author,
                         input: matches || msg.content,

--- a/src/structures/TagBuilder.js
+++ b/src/structures/TagBuilder.js
@@ -11,7 +11,7 @@ class TagBuilder {
     static SimpleTag(name) { return new TagBuilder().withCategory(bu.TagType.SIMPLE).withName(name); }
     static ComplexTag(name) { return new TagBuilder().withCategory(bu.TagType.COMPLEX).withName(name); }
     static ArrayTag(name) { return new TagBuilder().withCategory(bu.TagType.ARRAY).withName(name).acceptsArrays(true); }
-    static CCommandTag(name) { return new TagBuilder().withCategory(bu.TagType.CCOMMAND).withName(name); }
+    static BotTag(name) { return new TagBuilder().withCategory(bu.TagType.BOT).withName(name); }
     static APITag(name) { return new TagBuilder().withCategory(bu.TagType.API).withName(name); }
     static AutoTag(name) { return new TagBuilder().withCategory(0).withName(name); }
 
@@ -47,12 +47,6 @@ class TagBuilder {
         tag.execute = function (definition, resolveArgs, execConditional, execDefault) {
             return async function (subtag, context) {
                 try {
-                    if (definition.category === bu.TagType.CCOMMAND && !context.isCC)
-                        return TagBuilder.util.error(subtag, context, 'Can only use {' + definition.name + '} in CCommands');
-
-                    if (definition.staff && !await context.isStaff)
-                        return TagBuilder.util.error(subtag, context, 'Author must be staff');
-
                     let subtagArgs = subtag.children.slice(1);
 
                     let execArgs = resolveArgs != null
@@ -104,10 +98,6 @@ class TagBuilder {
     withProp(key, value) {
         this.properties[key] = value;
         return this;
-    }
-
-    requireStaff(staff = true) {
-        return this.withProp('staff', true);
     }
 
     acceptsArrays(array = true) {

--- a/src/structures/TagBuilder.js
+++ b/src/structures/TagBuilder.js
@@ -1,7 +1,11 @@
 const ArgFactory = require('./ArgumentFactory'),
     bbEngine = require('../structures/bbtag/Engine'),
     Timer = require('./Timer'),
-    Permission = require('eris/lib/structures/Permission');
+    Permission = require('eris/lib/structures/Permission'),
+    Context = require('./bbtag/Context'),
+    { SubTag, BBTag } = require('./bbtag/Tag');
+
+(Context, SubTag, BBTag);
 
 class TagBuilder {
     static SimpleTag(name) { return new TagBuilder().withCategory(bu.TagType.SIMPLE).withName(name); }
@@ -16,7 +20,7 @@ class TagBuilder {
         this.execute = {
             /** @type {number[]} */
             resolveArgs: null,
-            /** @type {{ contition: subtagCondition, action: subtagAction }} */
+            /** @type {{ contition: subtagCondition, action: subtagAction }[]} */
             conditional: [],
             /** @type {subtagAction} */
             default: null
@@ -358,21 +362,6 @@ module.exports = TagBuilder;
 console.info('TagBuilder loaded');
 
 /**
- * @param {SubTag} subtag The subtag content to be executed
- * @param {Context} context The context within which execution will take place
- * @param {(string|BBTag)[]} args The arguments given to the subtag. If `resolveArgs` is null, this will all be string
+ * @typedef {(subtag: SubTag, context: Context, args: (string | BBTag)[]) => any} subtagAction
+ * @typedef {(subtag: SubTag, context: Context, args: (string | BBTag)[]) => boolean | Promise<boolean>} subtagCondition
  */
-function subtagAction(subtag, context, args) {
-    //Dummy function, purely for JSDoc
-    return '';
-}
-
-/**
- * @param {SubTag} subtag The subtag content to be executed
- * @param {Context} context The context within which execution will take place
- * @param {(string|BBTag)[]} args The arguments given to the subtag. If `resolveArgs` is null, this will all be string
- */
-function subtagCondition(subtag, context, args) {
-    //Dummy function, purely for JSDoc
-    return false;
-}

--- a/src/structures/bbtag/Context.js
+++ b/src/structures/bbtag/Context.js
@@ -74,17 +74,8 @@ class Context {
         this.dbTimer = new Timer();
         this.dbObjectsCommitted = 0;
         this.state = {
-            count: {
-                dm: 0,
-                send: 0,
-                edit: 0,
-                delete: 0,
-                react: 0, // Not implemented, potential for the future
-                reactRemove: 0, // Not implemented, potential for the future
-                timer: 0,
-                loop: 0,
-                foreach: 0
-            },
+            /** @type {{[key:string]: limit}} */
+            limits: { ...(options.limits || {}) },
             query: {
                 count: 0,
                 user: {},
@@ -310,3 +301,9 @@ class Context {
 }
 
 module.exports = Context;
+
+/**
+ * @typedef {Object} limit
+ * @property {number} [limit.count] The remaining uses a subtag has. Leave undefined for unlimited
+ * @property {string} [limit.check] The function name inside the engine.checks property to use as a check
+ */

--- a/src/structures/bbtag/Context.js
+++ b/src/structures/bbtag/Context.js
@@ -306,4 +306,6 @@ module.exports = Context;
  * @typedef {Object} limit
  * @property {number} [limit.count] The remaining uses a subtag has. Leave undefined for unlimited
  * @property {string} [limit.check] The function name inside the engine.checks property to use as a check
+ * @property {boolean} [limit.disabled] The subtag is disabled and cannot be used at all
+ * @property {boolean} [limit.staff] The context.isStaff promise must return true
  */

--- a/src/structures/bbtag/Engine.js
+++ b/src/structures/bbtag/Engine.js
@@ -64,29 +64,14 @@ async function execute(bbtag, context) {
                 result.push(addError(subtag, context, 'Unknown subtag ' + name));
                 continue;
             }
+            subtag.name = name;
 
-            if (definition.name in context.state.limits) {
-                let limit = context.state.limits[definition.name];
-                if (limit && limit.count !== undefined) {
-                    if (limit.count === 0) {
-                        result.push(addError(subtag, context, 'Usage limit reached for ' + definition.name));
-                        continue;
-                    } else {
-                        limit.count--;
-                    }
-                }
-                if (limit && limit.check !== undefined) {
-                    if (limit.check in checks) {
-                        let check = checks[limit.check];
-                        if (!await check(context, subtag)) {
-                            result.push(addError(subtag, context, 'Usage limit reached for ' + definition.name));
-                            continue;
-                        }
-                    }
-                }
+            let limitError = await checkLimits(context, subtag, definition);
+            if (limitError) {
+                result.push(limitError);
+                continue;
             }
 
-            subtag.name = name;
             try {
                 result.push(await runSubtag(subtag, context));
             } catch (err) {
@@ -121,6 +106,41 @@ async function execute(bbtag, context) {
         result.push(content.slice(prevIndex, Math.max(prevIndex, bbtag.end - endOffset)));
     context.scopes.finishScope();
     return result.join('');
+}
+
+async function checkLimits(context, subtag, definition) {
+    let limit = context.state.limits[definition.name];
+    if (limit) {
+        if (limit.disabled) {
+            let scope = context.state.limits._name
+                ? `in ${context.state.limits._name}s`
+                : `for this trigger`;
+            return addError(subtag, context, `{${definition.name}} is disabled ${scope}`);
+        }
+        if (limit.staff) {
+            let isStaff = await context.isStaff;
+            if (!isStaff) {
+                return addError(subtag, context, 'Author must be staff');
+            }
+        }
+        if (limit.count !== undefined) {
+            if (limit.count === 0) {
+                return addError(subtag, context, 'Usage limit reached for ' + definition.name);
+            } else {
+                limit.count--;
+            }
+        }
+        if (limit.check !== undefined) {
+            if (limit.check in checks) {
+                let result = await checks[limit.check](context, subtag);
+                if (typeof result === 'boolean' && result) {
+                    return addError(subtag, context, 'Usage limit reached for ' + definition.name);
+                } else if (result) {
+                    return addError(subtag, context, result);
+                }
+            }
+        }
+    }
 }
 
 /**
@@ -227,7 +247,7 @@ async function runTag(content, context) {
     return { context, result, response };
 };
 
-/** @type {{[key:string]: (context: Context, subtag: SubTag) => boolean}} */
+/** @type {{[key:string]: (context: Context, subtag: SubTag) => boolean | string | Promise<boolean | string>}} */
 const checks = {};
 
 module.exports = {

--- a/src/tags/ban.js
+++ b/src/tags/ban.js
@@ -10,8 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('ban')
-        .requireStaff()
+    Builder.APITag('ban')
         .withArgs(a => [
             a.require('user'),
             a.optional('daysToDelete'),
@@ -19,13 +18,13 @@ module.exports =
             a.optional('timeToUnban'),
             a.optional('noperms')
         ]).withDesc('Bans `user`. ' +
-        'This functions the same as the ban command. ' +
-        'If the ban is successful, `Success` will be returned, unless a duration was provided in which case the duration in ms will be returned' +
-        'If `noperms` is provided, do not check if the command executor is actually able to ban people. ' +
-        'Only provide this if you know what you\'re doing.'
+            'This functions the same as the ban command. ' +
+            'If the ban is successful, `Success` will be returned, unless a duration was provided in which case the duration in ms will be returned' +
+            'If `noperms` is provided, do not check if the command executor is actually able to ban people. ' +
+            'Only provide this if you know what you\'re doing.'
         ).withExample(
-        '{ban;stupid cat;0;This is a test ban} @stupid cat was banned!',
-        'Success @stupid cat was banned!'
+            '{ban;stupid cat;0;This is a test ban} @stupid cat was banned!',
+            'Success @stupid cat was banned!'
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenArgs('1-5', async function (subtag, context, args) {

--- a/src/tags/delete.js
+++ b/src/tags/delete.js
@@ -24,9 +24,6 @@ module.exports =
         .whenArgs(2, async function (subtag, context, args) { return await this.deleteMessage(subtag, context, args[0], args[1]); })
         .whenDefault(Builder.errors.tooManyArguments)
         .withProp('deleteMessage', async function (subtag, context, channelId, messageId) {
-            if (++context.state.count.delete > 11)
-                return Builder.util.error(subtag, context, 'Delete limit reached (11)');
-
             if (!(await context.isStaff || context.ownsMessage(messageId)))
                 return Builder.util.error(subtag, context, 'Author must be staff to delete unrelated messages');
 

--- a/src/tags/dm.js
+++ b/src/tags/dm.js
@@ -11,8 +11,7 @@ const Builder = require('../structures/TagBuilder'),
     DMCache = {};
 
 module.exports =
-    Builder.CCommandTag('dm')
-        .requireStaff()
+    Builder.APITag('dm')
         .withArgs(a => [a.require('user'), a.require([a.optional('message'), a.optional('embed')])])
         .withDesc('DMs `user` the given `message` and `embed`. At least one of `message` and `embed` must be provided. ' +
             'You may only send one DM per execution. Requires author to be staff, and the user to be on the current guild.\n' +

--- a/src/tags/edit.js
+++ b/src/tags/edit.js
@@ -61,9 +61,6 @@ module.exports =
         })
         .whenDefault(Builder.errors.tooManyArguments)
         .withProp('runEdit', async function (subtag, context, channel, messageId, text, embed) {
-            if (++context.state.count.edit > 10)
-                return Builder.util.error(subtag, context, 'Edit limit reached (10)');
-
             if (!(await context.isStaff || context.ownsMessage(messageId)))
                 return Builder.util.error(subtag, context, 'Author must be staff to edit unrelated messages');
 

--- a/src/tags/exec.js
+++ b/src/tags/exec.js
@@ -11,12 +11,12 @@ const Builder = require('../structures/TagBuilder'),
     bbEngine = require('../structures/bbtag/Engine');
 
 module.exports =
-    Builder.AutoTag('exec')
+    Builder.BotTag('exec')
         .withArgs(a => [a.require('tag'), a.optional('args')])
         .withDesc('Executes another `tag`, giving it `args` as the input. Useful for modules.')
         .withExample(
-        'Let me do a tag for you. {exec;f}',
-        'Let me do a tag for you. User#1111 has paid their respects. Total respects given: 5'
+            'Let me do a tag for you. {exec;f}',
+            'Let me do a tag for you. User#1111 has paid their respects. Total respects given: 5'
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenDefault(async function (subtag, context, args) {

--- a/src/tags/execcc.js
+++ b/src/tags/execcc.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('execcc')
+    Builder.BotTag('execcc')
         .withArgs(a => [a.require('ccommand'), a.optional('args')])
         .withDesc('Executes `ccommand` using `args` as the input. Useful for modules.')
         .withExample(

--- a/src/tags/flag.js
+++ b/src/tags/flag.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('flag')
+    Builder.BotTag('flag')
         .withArgs(a => [a.require('code')])
         .withDesc('Returns the value of the specified case-sensitive flag code. Use `_` to get the values without a flag.')
         .withExample(

--- a/src/tags/flagset.js
+++ b/src/tags/flagset.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('flagset')
+    Builder.BotTag('flagset')
         .withArgs(a => [a.require('code')])
         .withDesc('Returns `true` or `false`, depending on whether the specified case-sensitive flag code has been set or not.')
         .withExample(

--- a/src/tags/for.js
+++ b/src/tags/for.js
@@ -56,9 +56,11 @@ module.exports =
             if (isNaN(increment)) errors.push('Increment must be a number');
             if (errors.length > 0) return Builder.util.error(subtag, context, errors.join(', '));
 
+            let remaining = context.state.limits.for || { loops: NaN };
+
             for (let i = initial; operator(i, limit); i += increment) {
-                context.state.count.loop += 1;
-                if (context.state.count.loop > 1500) {
+                remaining.loops--;
+                if (!(remaining.loops >= 0)) { // (remaining.loops < 0) would not work due to the comparison behaviours of NaN
                     result += Builder.errors.tooManyLoops(subtag, context);
                     break;
                 }

--- a/src/tags/foreach.js
+++ b/src/tags/foreach.js
@@ -27,8 +27,12 @@ module.exports =
                 arr = await bu.getArray(context, args[1]) || { v: args[1].split('') },
                 result = '';
             let array = Array.from(arr.v);
+
+            let remaining = context.state.limits.foreach || { loops: NaN };
+
             for (const item of array) {
-                if (++context.state.count.foreach > 3000) {
+                remaining.loops--;
+                if (!(remaining.loops >= 0)) { // (remaining.loops < 0) would not work due to the comparison behaviours of NaN
                     result += Builder.errors.tooManyLoops(subtag, context);
                     break;
                 }

--- a/src/tags/inject.js
+++ b/src/tags/inject.js
@@ -11,7 +11,7 @@ const Builder = require('../structures/TagBuilder'),
     exec = require('./exec');
 
 module.exports =
-    Builder.ComplexTag('inject')
+    Builder.BotTag('inject')
         .withArgs(a => a.require('code'))
         .withDesc('Executes any arbitrary BBTag that is within `code` and returns the result. Useful for making dynamic code, or as a testing tool (`{inject;{args}}`)')
         .withExample(

--- a/src/tags/kick.js
+++ b/src/tags/kick.js
@@ -10,20 +10,19 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('kick')
-        .requireStaff()
+    Builder.APITag('kick')
         .withArgs(a => [
             a.require('user'),
             a.optional('reason'),
             a.optional('noperms')
         ]).withDesc('Kicks `user`. ' +
-        'This functions the same as the kick command. ' +
-        'If the kick is successful, `Success` will be returned, otherwise the error will be given. ' +
-        'If `noperms` is provided, do not check if the command executor is actually able to kick people. ' +
-        'Only provide this if you know what you\'re doing.'
+            'This functions the same as the kick command. ' +
+            'If the kick is successful, `Success` will be returned, otherwise the error will be given. ' +
+            'If `noperms` is provided, do not check if the command executor is actually able to kick people. ' +
+            'Only provide this if you know what you\'re doing.'
         ).withExample(
-        '{kick;stupid cat;because I can} @stupid cat was kicked!',
-        'Success @stupid cat was kicked!'
+            '{kick;stupid cat;because I can} @stupid cat was kicked!',
+            'Success @stupid cat was kicked!'
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenArgs('1-3', async function (subtag, context, args) {

--- a/src/tags/lang.js
+++ b/src/tags/lang.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('lang')
+    Builder.BotTag('lang')
         .withArgs(a => a.require('language'))
         .isDeprecated(true)
         .withDesc('Specifies which `language` should be used when viewing the raw of this tag')

--- a/src/tags/modlog.js
+++ b/src/tags/modlog.js
@@ -10,8 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('modlog')
-        .requireStaff()
+    Builder.BotTag('modlog')
         .withArgs(a => [
             a.require('action'),
             a.require('user'),

--- a/src/tags/nsfw.js
+++ b/src/tags/nsfw.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('nsfw')
+    Builder.BotTag('nsfw')
         .withArgs(a => a.optional('message'))
         .withDesc('Marks the output as being NSFW, and only to be sent in NSFW channels. A requirement for any tag with NSFW content. ' +
             '`message` is the error to show, defaults to "❌ This contains NSFW content! Go to a NSFW channel. ❌"')

--- a/src/tags/output.js
+++ b/src/tags/output.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.APITag('output')
+    Builder.BotTag('output')
         .withArgs(a => a.optional('text'))
         .withDesc('Forces an early send of the default output message, using `text` as the text to show. ' +
             'If this is used then there will be no output sent once the tag finishes. Only 1 `{output}` may be used per ' +

--- a/src/tags/pardon.js
+++ b/src/tags/pardon.js
@@ -10,8 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('pardon')
-        .requireStaff()
+    Builder.BotTag('pardon')
         .withArgs(a => [
             a.optional('user'),
             a.optional('count'),

--- a/src/tags/prefix.js
+++ b/src/tags/prefix.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('prefix')
+    Builder.BotTag('prefix')
         .withDesc('Gets the current guild\'s prefix.')
         .withExample(
             'Your prefix is {prefix}',

--- a/src/tags/quiet.js
+++ b/src/tags/quiet.js
@@ -2,7 +2,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('quiet')
+    Builder.BotTag('quiet')
         .acceptsArrays()
         .withArgs(a => a.optional('isQuiet'))
         .withDesc('Tells any subtags that rely on a `quiet` field to be/not be quiet based on `isQuiet`. `isQuiet` defaults to `true`')

--- a/src/tags/reason.js
+++ b/src/tags/reason.js
@@ -10,12 +10,12 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('reason')
+    Builder.BotTag('reason')
         .withArgs(a => [a.require('reason')])
         .withDesc('Sets the reason for the next API call (ex. roleadd, roleremove, ban, etc.)')
         .withExample(
-        '{reason;This will show up in the audit logs!}{roleadd;111111111111}',
-        ''
+            '{reason;This will show up in the audit logs!}{roleadd;111111111111}',
+            ''
         )
         .whenArgs('0', async function (subtag, context, args) {
             context.scope.reason = undefined;

--- a/src/tags/repeat.js
+++ b/src/tags/repeat.js
@@ -30,9 +30,11 @@ module.exports =
 
             if (amount < 0) return Builder.util.error(subtag, context, 'Cant be negative');
 
+            let remaining = context.state.limits.repeat || { loops: NaN };
+
             for (let i = 0; i < amount; i++) {
-                context.state.count.loop += 1;
-                if (context.state.count.loop > 1500) {
+                remaining.loops--;
+                if (!(remaining.loops >= 0)) { // (remaining.loops < 0) would not work due to the comparison behaviours of NaN
                     result += Builder.errors.tooManyLoops(subtag, context);
                     break;
                 }

--- a/src/tags/roleadd.js
+++ b/src/tags/roleadd.js
@@ -11,17 +11,16 @@ const Builder = require('../structures/TagBuilder');
 const userHasRole = require('./userhasrole');
 
 module.exports =
-    Builder.CCommandTag('roleadd')
-        .requireStaff()
+    Builder.APITag('roleadd')
         .withAlias('addrole')
         .withArgs(a => [a.require('role'), a.optional('user'), a.optional('quiet')])
         .withDesc('Gives `user` the chosen `role`, where `role` is a role ID or mention. ' +
-        'You can find a list of roles and their ids by doing `b!roles`. ' +
-        'Returns `true` if `role` was given, and `false` otherwise. ' +
-        'If `quiet` is specified, if a user can\'t be found it will simply return `false`'
+            'You can find a list of roles and their ids by doing `b!roles`. ' +
+            'Returns `true` if `role` was given, and `false` otherwise. ' +
+            'If `quiet` is specified, if a user can\'t be found it will simply return `false`'
         ).withExample(
-        'Have a role! {roleadd;11111111111111111}',
-        'Have a role! true'
+            'Have a role! {roleadd;11111111111111111}',
+            'Have a role! true'
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenArgs('1-3', async function (subtag, context, args) {

--- a/src/tags/rolecreate.js
+++ b/src/tags/rolecreate.js
@@ -10,8 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('rolecreate')
-        .requireStaff()
+    Builder.APITag('rolecreate')
         .withArgs(a => [
             a.require('name'),
             a.optional('color'),
@@ -20,14 +19,14 @@ module.exports =
             a.optional('hoisted')
         ])
         .withDesc('Creates a role with the given information. ' +
-        '`color` can be a [HTML color](https://www.w3schools.com/colors/colors_names.asp), hex, (r,g,b) or a valid color number. ' +
-        'Provide `permissions` as a number, which can be calculated [here](https://discordapi.com/permissions.html) ' +
-        '`hoisted` is if the role should be displayed separately from other roles ' +
-        '`color` defaults to #000000 (uncolored role), `permissions` defaults to 0, `mentionable` defaults to false, `hoisted` defaults to false. ' +
-        'Returns the new role\'s ID.')
+            '`color` can be a [HTML color](https://www.w3schools.com/colors/colors_names.asp), hex, (r,g,b) or a valid color number. ' +
+            'Provide `permissions` as a number, which can be calculated [here](https://discordapi.com/permissions.html) ' +
+            '`hoisted` is if the role should be displayed separately from other roles ' +
+            '`color` defaults to #000000 (uncolored role), `permissions` defaults to 0, `mentionable` defaults to false, `hoisted` defaults to false. ' +
+            'Returns the new role\'s ID.')
         .withExample(
-        '{rolecreate;Super Cool Role!;ff0000;0;false;true}',
-        '11111111111111111'
+            '{rolecreate;Super Cool Role!;ff0000;0;false;true}',
+            '11111111111111111'
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenArgs('1-5', async function (subtag, context, args) {

--- a/src/tags/roledelete.js
+++ b/src/tags/roledelete.js
@@ -10,13 +10,12 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('roledelete')
-        .requireStaff()
+    Builder.APITag('roledelete')
         .withArgs(a => [a.require('role'), a.optional('quiet')])
         .withDesc('Deletes `role`. If `quiet` is specified, if `role` can\'t be found it will return nothing')
         .withExample(
-        '{roledelete;Super Cool Role!}',
-        '(rip no more super cool roles for anyone)'
+            '{roledelete;Super Cool Role!}',
+            '(rip no more super cool roles for anyone)'
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenArgs('1-2', async function (subtag, context, args) {

--- a/src/tags/rolemention.js
+++ b/src/tags/rolemention.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('rolemention')
+    Builder.APITag('rolemention')
         .withArgs(a => [a.require('role'), a.optional('quiet')])
         .withDesc('Returns a mention of `role`. ' +
             'If `quiet` is specified, if `role` can\'t be found it will simply return nothing.')

--- a/src/tags/roleremove.js
+++ b/src/tags/roleremove.js
@@ -10,17 +10,16 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('roleremove')
-        .requireStaff()
+    Builder.APITag('roleremove')
         .withAlias('removerole')
         .withArgs(a => [a.require('role'), a.optional('user'), a.optional('quiet')])
         .withDesc('Removes `role` from `user`, where `role` is a role ID or mention. ' +
-        'You can find a list of roles and their ids by doing \`b!roles\`. ' +
-        'Returns true if `role` was removed, and false otherwise.' +
-        'If `quiet` is specified, if a user can\'t be found it will simply return `false`'
+            'You can find a list of roles and their ids by doing \`b!roles\`. ' +
+            'Returns true if `role` was removed, and false otherwise.' +
+            'If `quiet` is specified, if a user can\'t be found it will simply return `false`'
         ).withExample(
-        'No more role! {roleremove;11111111111111111}',
-        'No more role! true'
+            'No more role! {roleremove;11111111111111111}',
+            'No more role! true'
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenArgs('1-3', async function (subtag, context, args) {

--- a/src/tags/rolesetmentionable.js
+++ b/src/tags/rolesetmentionable.js
@@ -10,8 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('rolesetmentionable')
-        .requireStaff()
+    Builder.APITag('rolesetmentionable')
         .withArgs(a => [a.require('role'), a.optional('value'), a.optional('quiet')])
         .withDesc('Sets whether `role` can be mentioned. `value` can be either `true` to set the role as mentionable, ' +
             'or anything else to set it to unmentionable. If `value` isn\'t provided, defaults to `true`. ' +

--- a/src/tags/send.js
+++ b/src/tags/send.js
@@ -10,8 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('send')
-        .requireStaff()
+    Builder.APITag('send')
         .withArgs(a => [a.require('channel'), a.require([a.optional('message'), a.optional('embed')])])
         .withDesc('Sends `message` and `embed` to `channel`, and returns the message ID. `channel` is either an ID or channel mention. ' +
             'At least one out of `message` and `embed` must be supplied.\n' +

--- a/src/tags/subtagexists.js
+++ b/src/tags/subtagexists.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('subtagexists')
+    Builder.BotTag('subtagexists')
         .withArgs(a => a.require('subTag'))
         .withDesc('Checks to see if `subTag` exists.')
         .withExample(

--- a/src/tags/suppresslookup.js
+++ b/src/tags/suppresslookup.js
@@ -10,12 +10,12 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.AutoTag('suppresslookup')
+    Builder.BotTag('suppresslookup')
         .withArgs(a => [a.optional('value')])
         .withDesc('Sets whether error messages in the lookup system (query canceled, nothing found) should be suppressed. `value` must be a boolean, and defaults to `true`.')
         .withExample(
-        '{suppresslookup}',
-        ''
+            '{suppresslookup}',
+            ''
         )
         .whenArgs('0-1', async function (subtag, context, args) {
             let suppress = true;

--- a/src/tags/timer.js
+++ b/src/tags/timer.js
@@ -11,7 +11,7 @@ const Builder = require('../structures/TagBuilder');
 const moment = require('moment-timezone');
 
 module.exports =
-    Builder.CCommandTag('timer')
+    Builder.BotTag('timer')
         .withArgs(a => [a.require('code'), a.require('duration')])
         .withDesc('Executes `code` after `duration`. ' +
             'Three timers are allowed per custom command, with no recursive timers.')

--- a/src/tags/unban.js
+++ b/src/tags/unban.js
@@ -10,15 +10,14 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('unban')
-        .requireStaff()
+    Builder.APITag('unban')
         .withArgs(a => [a.require('user'), a.optional('reason'), a.optional('noperms')])
         .withDesc('Unbans `user` with the given `reason`. This functions the same as the unban command. ' +
-        'If `noperms` is provided, do not check if the command executor is actually able to ban people. ' +
-        'Only provide this if you know what you\'re doing.')
+            'If `noperms` is provided, do not check if the command executor is actually able to ban people. ' +
+            'Only provide this if you know what you\'re doing.')
         .withExample(
-        '{unban;@user;0;This is a test unban}@user was unbanned!',
-        '@user was unbanned!'
+            '{unban;@user;0;This is a test unban}@user was unbanned!',
+            '@user was unbanned!'
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenArgs('1-3', async function (subtag, context, args) {

--- a/src/tags/usersetnick.js
+++ b/src/tags/usersetnick.js
@@ -10,14 +10,13 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('usersetnick')
+    Builder.APITag('usersetnick')
         .withAlias('setnick')
-        .requireStaff()
         .withArgs(a => [a.require('nick'), a.optional('user')])
         .withDesc('Sets `user`\'s nickname to `nick`. Leave `nick` blank to reset their nickname.')
         .withExample(
-        '{usersetnick;super cool nickname}',
-        ''
+            '{usersetnick;super cool nickname}',
+            ''
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenArgs('1-2', async function (subtag, context, args) {

--- a/src/tags/waitmessage.js
+++ b/src/tags/waitmessage.js
@@ -39,7 +39,7 @@ const overrideSubtags = [
 ];
 
 module.exports =
-    Builder.APITag('waitmessage')
+    Builder.BotTag('waitmessage')
         .withArgs(a => [
             a.optional('channels'),
             a.optional('users'),

--- a/src/tags/waitreact.js
+++ b/src/tags/waitreact.js
@@ -18,7 +18,7 @@ function padEmoji(emoji) {
 }
 
 module.exports =
-    Builder.APITag('waitreaction')
+    Builder.BotTag('waitreaction')
         .withAlias('waitreact')
         .withArgs(a => [
             a.require('messages'),

--- a/src/tags/warn.js
+++ b/src/tags/warn.js
@@ -10,8 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('warn')
-        .requireStaff()
+    Builder.BotTag('warn')
         .withArgs(a => [a.optional('user'), a.optional('count'), a.optional('reason')])
         .withDesc('Gives `user` the specified number of warnings with the given reason, and returns their new warning count. ' +
             '`user` defaults to the authorizer of the tag. `count` defaults to 1.')

--- a/src/tags/warnings.js
+++ b/src/tags/warnings.js
@@ -10,8 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.CCommandTag('warnings')
-        .requireStaff()
+    Builder.BotTag('warnings')
         .withArgs(a => a.optional('user'))
         .withDesc('Gets the number of warnings `user` has. `user` defaults to the user who executed the containing tag.')
         .withExample(

--- a/src/utils/constant.js
+++ b/src/utils/constant.js
@@ -26,7 +26,7 @@ bu.TagType = {
     SIMPLE: 1,
     COMPLEX: 2,
     ARRAY: 3,
-    CCOMMAND: 4,
+    BOT: 4,
     API: 5,
     properties: {
         1: {
@@ -42,8 +42,8 @@ bu.TagType = {
             desc: 'Subtags designed specifically for arrays.'
         },
         4: {
-            name: 'Custom Command',
-            desc: 'Subtags that only work in custom commands.'
+            name: 'Blargbot',
+            desc: 'Subtags that integrate with blargbots custom functions.'
         },
         5: {
             name: 'API',


### PR DESCRIPTION
Usage limits on subtags have been reworked to be managed by the engine rather than the subtag itself. This has been done to allow more fine control over what is able to be used and how much on an execution context basis

I havent added any restrictions to autoresponses yet, however I have made a place for them to be specified
https://github.com/blargbot/blargbot/blob/dev/rework-subtag-limits/src/core/bbtag.js#L522

We also need to add a migration for timers to the new system of storing limits. The old system consisted of a counter and a cap. The new system is a count which is reduced on each use.