### PR TITLE
Add a warning to 'roledelete'

### DIFF
--- a/src/tags/roledelete.js
+++ b/src/tags/roledelete.js
@@ -12,7 +12,7 @@ const Builder = require('../structures/TagBuilder');
 module.exports =
     Builder.APITag('roledelete')
         .withArgs(a => [a.require('role'), a.optional('quiet')])
-        .withDesc('Deletes `role`. If `quiet` is specified, if `role` can\'t be found it will return nothing')
+        .withDesc('Deletes `role`. If `quiet` is specified, if `role` can\'t be found it will return nothing.\nWarning: this subtag is able to delete roles managed by integrations.')
         .withExample(
             '{roledelete;Super Cool Role!}',
             '(rip no more super cool roles for anyone)'


### PR DESCRIPTION
The description now highlights that this tag is able to delete roles managed by integrations that shouldn't be editable by user accounts.