### PR TITLE
Tweak unsafe regex detection and mention it in the docs

### DIFF
--- a/src/dcommands/autoresponse.js
+++ b/src/dcommands/autoresponse.js
@@ -11,7 +11,7 @@ class autoresponseCommand extends BaseCommand {
             flags: [{
                 flag: 'R',
                 word: 'regex',
-                desc: 'If specified, parse as /regex/ rather than plaintext.'
+                desc: 'If specified, parse as /regex/ rather than plaintext. Unsafe and very long (more than 2000 characters) regexes will not parse successfully.'
             }, {
                 flag: 'e',
                 word: 'everything',

--- a/src/dcommands/censor.js
+++ b/src/dcommands/censor.js
@@ -10,7 +10,7 @@ class CensorCommand extends BaseCommand {
             flags: [{
                 flag: 'R',
                 word: 'regex',
-                desc: 'Add/Edit: If specified, parse as /regex/ rather than plaintext.'
+                desc: 'Add/Edit: If specified, parse as /regex/ rather than plaintext. Unsafe and very long (more than 2000 characters) regexes will not parse successfully.'
             },
             {
                 flag: 'w',

--- a/src/tags/regexmatch.js
+++ b/src/tags/regexmatch.js
@@ -13,7 +13,9 @@ module.exports =
     Builder.ArrayTag('regexmatch')
         .withAlias('match')
         .withArgs(a => [a.require('text'), a.require('regex')])
-        .withDesc('Returns an array of everything in `text` that matches `regex`.')
+        .withDesc('Returns an array of everything in `text` that matches `regex`. ' +
+            '`regex` will only succeed to compile if it is deemed a safe regular expression ' +
+            '(safe regexes do not run in exponential time for any input) and is less than 2000 characters long.')
         .withExample(
             '{regexmatch;I have $1 and 25 cents;/\\d+/g}',
             '["1", "25"]'

--- a/src/tags/regexreplace.js
+++ b/src/tags/regexreplace.js
@@ -14,7 +14,9 @@ module.exports =
         .withArgs(a => [a.optional('text'), a.require('regex'), a.require('replaceWith')])
         .withDesc('Replaces the `regex` phrase with `replacewith`. ' +
             'If `text` is specified, the tag is replaced with the new `toreplace`. ' +
-            'If not, it is run on the output from the containing tag.')
+            'If not, it is run on the output from the containing tag. ' +
+            '`regex` will only succeed to compile if it is deemed a safe regular expression ' +
+            '(safe regexes do not run in exponential time for any input) and is less than 2000 characters long.')
         .withExample(
             'I like {regexreplace;to consume;/o/gi;a} cheese. {regexreplace;/e/gi;n}',
             'I likn ta cansumn chnnsn.'

--- a/src/tags/regexsplit.js
+++ b/src/tags/regexsplit.js
@@ -12,7 +12,9 @@ const Builder = require('../structures/TagBuilder');
 module.exports =
     Builder.AutoTag('regexsplit')
         .withArgs(a => [a.require('text'), a.require('regex')])
-        .withDesc('Splits the given text using the given `regex` as the split rule')
+        .withDesc('Splits the given text using the given `regex` as the split rule. ' +
+            '`regex` will only succeed to compile if it is deemed a safe regular expression ' +
+            '(safe regexes do not run in exponential time for any input) and is less than 2000 characters long.')
         .withExample(
             '{regexsplit;Hello      there, I       am hungry;/[\\s,]+/}',
             '["Hello","there","I","am","hungry"]'

--- a/src/tags/regextest.js
+++ b/src/tags/regextest.js
@@ -12,7 +12,9 @@ const Builder = require('../structures/TagBuilder');
 module.exports =
     Builder.AutoTag('regextest')
         .withArgs(a => [a.require('text'), a.require('regex')])
-        .withDesc('Tests if the `regex` phrase matches the `text`, and returns a boolean (true/false).')
+        .withDesc('Tests if the `regex` phrase matches the `text`, and returns a boolean (true/false). ' +
+            '`regex` will only succeed to compile if it is deemed a safe regular expression ' +
+            '(safe regexes do not run in exponential time for any input) and is less than 2000 characters long.')
         .withExample(
             '{regextest;apple;/p+/i} {regextest;banana;/p+/i}',
             'true false'

--- a/src/utils/generic.js
+++ b/src/utils/generic.js
@@ -1384,9 +1384,6 @@ bu.createRegExp = function (term) {
     if (/^\/?.*\/.*/.test(term)) {
         let regexList = term.match(/^\/?(.*)\/(.*)/);
 
-        if (regexList[1].match(/\(.*[*+].*\)[+*]/))
-            throw new Error('Unsafe Regex');
-
         let temp = new RegExp(regexList[1], regexList[2]);
         if (!isSafeRegex(temp)) {
             throw new Error('Unsafe Regex');


### PR DESCRIPTION
This PR proposes the removal of an apparently spurious unsafe regex check, that should be already covered by the library call which follows with less false positives, and updates the documentation of the commands and tags which use `bu.createRegExp` to indicate that regexes will be checked against safety and length.

I did this PR in a bit of a rush from my web browser. I think it should work, as it is a simple check removal and string modification, but perhaps I missed something or I did something essentially wrong, so I'm open to changes.

Resolves #159.