### PR TITLE
Fixing the check statement for the "markdown box"

### DIFF
--- a/src/dcommands/ccommand.js
+++ b/src/dcommands/ccommand.js
@@ -687,7 +687,7 @@ ${command[0].desc}`);
                                         duration.asSeconds() + 's' : duration.asMilliseconds() + 'ms';
                                 }
                                 let lines = [text];
-                                if (args[0] === 'vtest') {
+                                if (words[1] === 'vtest') {
                                     lines.push('```js',
                                         `         Execution Time: ${formatDuration(context.execTimer.duration)}`,
                                         `    Variables Committed: ${context.dbObjectsCommitted}`,

--- a/src/dcommands/tag.js
+++ b/src/dcommands/tag.js
@@ -659,7 +659,7 @@ It has been favourited **${count || 0} time${(count || 0) == 1 ? '' : 's'}**!`;
                                         duration.asSeconds() + 's' : duration.asMilliseconds() + 'ms';
                                 }
                                 let lines = [text];
-                                if (args[0] === 'vtest') {
+                                if (words[1] === 'vtest') {
                                     lines.push('```js',
                                         `         Execution Time: ${formatDuration(context.execTimer.duration)}`,
                                         `    Variables Committed: ${context.dbObjectsCommitted}`,


### PR DESCRIPTION
Thanks to Neila#9580 for pointing out the box wasn't displayed when using the appropriate subcommand ´vtest´.