### PR TITLE
Bugs/splitinput newline

### DIFF
--- a/src/utils/generic.js
+++ b/src/utils/generic.js
@@ -1031,10 +1031,13 @@ function* tokenizeInput(source) {
 function* nextInputTokens(state, offset, type) {
     if (state.from != state.to) {
         yield { type: tokenTypes.TEXT, content: state.source.substring(state.from, state.to) };
+        state.from = state.to;
     }
-    state.from = state.to;
-    if (type) {
-        offset(state);
+    if (!type) {
+        return;
+    }
+    offset(state);
+    if (state.from != state.to) {
         yield { type, content: state.source.substring(state.from, state.to) };
         state.from = state.to;
     }


### PR DESCRIPTION
Reworked the splitinput method to respect all whitespace characters, not just spaces.
Reworked to use a generator function to try to make it more readable.

Sample test:
![image](https://user-images.githubusercontent.com/7736591/59915366-5d795400-9414-11e9-82c8-df1c501df42e.png)
