### PR TITLE
Fix the analysis of subtags at the point of setting

### DIFF
--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -408,6 +408,10 @@ function* analyzeSubtag(subtag, parents) {
         return;
     } else if (name.children.length > 0) {
         yield { subtag, warning: 'Dynamic subtag' };
+        for (const child of subtag.children) {
+            yield* analyzeString(child, parents);
+        }
+        return;
     }
 
     const nameStr = name.content.toLowerCase();
@@ -422,7 +426,7 @@ function* analyzeSubtag(subtag, parents) {
         }
     }
 
-    const definition = findSubtag(nameStr, parent);
+    const definition = findSubtag(nameStr, parents);
 
     if (!definition) {
         yield { subtag, error: `Unknown subtag {${name.content}}` };
@@ -434,6 +438,7 @@ function* analyzeSubtag(subtag, parents) {
                 : '')
         };
     }
+
 
     parents.push(nameStr);
     for (const child of subtag.children) {
@@ -448,14 +453,14 @@ function* analyzeSubtag(subtag, parents) {
  * @returns {{deprecated: boolean} | undefined}
  */
 function findSubtag(name, parents) {
-    const definition = TagManager.get(nameStr);
+    const definition = TagManager.get(name);
     if (definition) {
         return definition;
     }
     if (name.startsWith('func.')) {
         return { deprecated: false };
     }
-    if (['params', 'paramsarray', 'paramslength'].includes(nameStr) && parents.some(p => p === 'func' || p === 'function')) {
+    if (['params', 'paramsarray', 'paramslength'].includes(name) && parents.some(p => p === 'func' || p === 'function')) {
         return { deprecated: false };
     }
 }

--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -410,7 +410,6 @@ function* analyzeSubtag(subtag, parents) {
         yield { subtag, warning: 'Dynamic subtag' };
     }
 
-    yield* analyzeString(name, parents);
     const nameStr = name.content.toLowerCase();
     if (nameStr === '//') { return; }
 

--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -402,6 +402,9 @@ function* analyzeSubtag(subtag, parents) {
     const name = subtag.name;
     if (!name || !name.content) {
         yield { subtag, error: 'Unnamed subtag' };
+        for (const child of subtag.children) {
+            yield* analyzeString(child, parents);
+        }
         return;
     } else if (name.children.length > 0) {
         yield { subtag, warning: 'Dynamic subtag' };

--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -9,7 +9,8 @@
 
 const argFactory = require('../structures/ArgumentFactory'),
     af = argFactory,
-    bbEngine = require('../structures/bbtag/Engine');
+    bbEngine = require('../structures/bbtag/Engine'),
+    { BBTag, SubTag } = require('../structures/bbtag/Tag');
 
 async function executeTag(msg, tagName, command) {
     let tag = await r.table('tag').get(tagName).run();
@@ -358,50 +359,125 @@ function generateDebug(code, context) {
     };
 };
 
+/**
+ *
+ * @param {string} code
+ * @returns {AnalysisResult[]}
+ */
 function analyze(code) {
     let parsed = bbEngine.parse(code);
     if (!parsed.success) {
         return parsed.error;
     }
-    let subtags = getSubTags(parsed.bbtag);
-    let result = [];
+    return [...analyzeString(parsed.bbtag, [])];
+}
 
-    for (const subtag of subtags) {
-        let name = (subtag.children || [])[0];
-        if (!name || !name.content) {
-            result.push({
-                subtag,
-                error: 'Unnamed subtag'
-            });
-        } else if (name.children.length > 0) {
-            result.push({
-                subtag,
-                warning: 'Dynamic subtag'
-            });
-        } else {
-            let definition = TagManager.get(name.content);
-            if (!definition) {
-                if (!name.content.toLowerCase().startsWith('func.'))
-                    result.push({
-                        subtag,
-                        error: `Unknown subtag {${name.content}}`
-                    });
-            } else if (definition.deprecated) {
-                result.push({
-                    subtag,
-                    warning: `{${name.content}} is deprecated` + (typeof definition.deprecated === 'string'
-                        ? `. Please use {${definition.deprecated}} instead`
-                        : '')
-                });
-            }
+/** 
+ * @typedef {Object} AnalysisResult 
+ * @property {SubTag} subtag
+ * @property {string} [error]
+ * @property {string} [warning]
+ * */
+
+
+/**
+ * 
+ * @param {BBTag} bbtag
+ * @param {string[]} parents
+ * @returns {IterableIterator<AnalysisResult>}
+ */
+function* analyzeString(bbtag, parents) {
+    for (const child of bbtag.children) {
+        yield* analyzeSubtag(child, parents);
+    }
+}
+
+/**
+ * 
+ * @param {SubTag} subtag
+ * @param {string[]} parents
+ * @returns {IterableIterator<AnalysisResult>}
+ */
+function* analyzeSubtag(subtag, parents) {
+    const name = subtag.name;
+    if (!name || !name.content) {
+        yield { subtag, error: 'Unnamed subtag' };
+        return;
+    } else if (name.children.length > 0) {
+        yield { subtag, warning: 'Dynamic subtag' };
+    }
+
+    yield* analyzeString(name, parents);
+    const nameStr = name.content.toLowerCase();
+    if (nameStr === '//') { return; }
+
+    if (['lock'].includes(nameStr) && parents.includes('lock')) {
+        yield { subtag, error: '{lock} subtags cannot be nested' };
+    } else if (TagManager.get('waitmessage').overrideSubtags.includes(nameStr)) {
+        const parent = parents.find(n => ['waitmessage', 'waitreact', 'filter'].includes(n));
+        if (parent) {
+            yield { subtag, error: `Cannot use {${nameStr}} inside of {${parent}}` };
         }
     }
 
-    return result;
+    const definition = findSubtag(nameStr, parent);
+
+    if (!definition) {
+        yield { subtag, error: `Unknown subtag {${name.content}}` };
+    } else if (definition.deprecated) {
+        yield {
+            subtag,
+            warning: `{${nameStr}} is deprecated` + (typeof definition.deprecated === 'string'
+                ? `. Please use {${definition.deprecated}} instead`
+                : '')
+        };
+    }
+
+    parents.push(nameStr);
+    for (const child of subtag.children) {
+        yield* analyzeString(child, parents);
+    }
+    parents.pop();
+}
+
+/**
+ * @param {string} name
+ * @param {string[]} parents
+ * @returns {{deprecated: boolean} | undefined}
+ */
+function findSubtag(name, parents) {
+    const definition = TagManager.get(nameStr);
+    if (definition) {
+        return definition;
+    }
+    if (name.startsWith('func.')) {
+        return { deprecated: false };
+    }
+    if (['params', 'paramsarray', 'paramslength'].includes(nameStr) && parents.some(p => p === 'func' || p === 'function')) {
+        return { deprecated: false };
+    }
+}
+
+/**
+ * 
+ * @param {SubTag} subtag
+ * @param {(name: string) => boolean} check
+ * @returns {boolean}
+ */
+function findParent(subtag, check) {
+    while (subtag.parent && subtag.parent.parent) {
+        subtag = subtag.parent.parent;
+        const name = subtag.children[0];
+        if (!name) { continue; }
+        if (check(name.content)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 function addAnalysis(code, baseText) {
-    let analysis = bbtag.analyze(code);
+    let analysis = analyze(code);
     if (typeof analysis === 'string') {
         baseText += `\n${analysis}`;
     } else {
@@ -416,18 +492,6 @@ function addAnalysis(code, baseText) {
     }
 
     return baseText;
-}
-
-function getSubTags(bbstring) {
-    return bbstring.children.reduce(function (accumulator, part) {
-        if (typeof part !== 'string') {
-            accumulator.push(part);
-            for (const arg of part.children) {
-                accumulator.push(...getSubTags(arg));
-            }
-        }
-        return accumulator;
-    }, []);
 }
 
 function viewErrors(...errors) {

--- a/src/structures/bbtag/Tag.js
+++ b/src/structures/bbtag/Tag.js
@@ -5,6 +5,7 @@ const { Range } = require('../Position');
 
 /**
  * This represents a block of text within the BBTag language.
+ * @template T
  */
 class BaseTag {
 
@@ -34,23 +35,18 @@ class BaseTag {
     */
     get content() { return this.source.slice(this.start, this.end); }
     /** 
-     * @type {BBTag?}
+     * @type {T?}
      * The tag which this tag is contained within
      * */
     get parent() { return this._protected.parent; }
     /** 
-     * @type {SubTag[]}
+     * @type {T[]}
      * All the tags contained withinin this tag
      * */
     get children() { return this._protected.children; }
 
-    /** @param {string|BaseTag} parent The parent of this tag */
+    /** @param {string|T} parent The parent of this tag */
     constructor(parent) {
-        /**
-         * The protected properties of this tag
-         * @type {BaseTagProtected}
-         * @protected
-         */
         this._protected = {
             children: []
         };
@@ -66,8 +62,11 @@ class BaseTag {
 /**
  * This represents a recognized subtag structure. Subtags are strings starting and ending with {}
  * And contain sections of BBTag delimited by ;
+ * @extends {BaseTag<BBTag>}
  */
 class SubTag extends BaseTag {
+    get name() { return this.children[0]; }
+
     /**
      * Attempts to create a SubTag object from the given values.
      * @param {BBTag} parent The parent to use for creation of this SubTag instance
@@ -89,11 +88,9 @@ class SubTag extends BaseTag {
     }
 
 
-    /** @param {string|SubTag} parent */
+    /** @param {string|BBTag} parent */
     constructor(parent) {
         super(parent);
-        /** @type {BaseTag|string} */
-        this.name = this.children[0];
     }
 
     /**
@@ -123,6 +120,7 @@ class SubTag extends BaseTag {
 /**
  * This represents both the top level text, and the contents of each argument in a subtag.
  * A subtag is a block of text between and including a {} pair, with arguments delimited by ;
+ * @extends {BaseTag<SubTag>}
  */
 class BBTag extends BaseTag {
     /**


### PR DESCRIPTION
I know this PR is a bit rough, but I have plans for a proper implementation in the rewrite I am doing.

Changes from the current implementation:

1. No analysis within `{//}`
2. `{params}`, `{paramsarray}` and `{paramslength}` no longer report as errors when used within `{function}`
3. `{lock}` reports an error when used within `{lock}`
4. Restrictions on `{waitreact}`, `{waitmessage}` and `{filter}` are reported