### PR TITLE
Added UserID to the user get list

### DIFF
--- a/src/utils/generic.js
+++ b/src/utils/generic.js
@@ -606,7 +606,7 @@ bu.getUser = async function (msg, name, args = {}) {
                 newUserList.push(userList[i]);
             }
             for (let i = 0; i < newUserList.length; i++) {
-                userListString += `${i + 1 < 10 ? ' ' + (i + 1) : i + 1}. ${newUserList[i].user.username}#${newUserList[i].user.discriminator}\n`;
+                userListString += `${i + 1 < 10 ? ' ' + (i + 1) : i + 1}. ${newUserList[i].user.username}#${newUserList[i].user.discriminator} - ${newUserList[i].user.id}\n`;
             }
             let moreUserString = newUserList.length < userList.length ? `...and ${userList.length - newUserList.length}more.\n` : '';
             try {


### PR DESCRIPTION
Added UserID to the user get list
these days we need UserID's too. To use it directly with other bots that only support UserID's, very useful to get bots or get their userid very fast.

If you think, you can use the user discrimination with blargbot, yeah but, probably not sure haven't tested it but I use another bot that logs infractions and it only supports UserID's. Also this is not bad to list UserID's to directly report them.

Please add it

https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwDg5WovcwMA9NIL/recXjAjG3xzMaQbmd?blocks=bipip3uBZFRPcSy3C


should this be added, then please build it