### PR TITLE
Add subcommand "setauthorizer" to claim authorizer role of a ccommand

### DIFF
--- a/src/dcommands/ccommand.js
+++ b/src/dcommands/ccommand.js
@@ -695,7 +695,7 @@ class CcommandCommand extends BaseCommand {
                             break;
                         }
                         author = await r.table('user').get(tag.author).run();
-                        if (author !== msg.author.id) {
+                        if (author.id != msg.author.id) {
                             bu.send(msg, 'You don\'t own that custom command!');
                             break;
                         }

--- a/src/dcommands/ccommand.js
+++ b/src/dcommands/ccommand.js
@@ -12,8 +12,8 @@ const subcommands = [
     },
     {
         name: 'setauthorizer',
-        args: '<name> [authorizer]',
-        desc: 'Set the custom command\'s authorizer'
+        args: '<name>',
+        desc: 'Set the executing user as the custom command\'s authorizer'
     },
     {
         name: 'cooldown',
@@ -688,26 +688,17 @@ class CcommandCommand extends BaseCommand {
                     break;
                 case 'setauthorizer':
                     if (words.length > 2) {
-                        let authorizer, author;
                         title = filterTitle(words[2]);
                         tag = await bu.ccommand.get(msg.channel.guild.id, title);
                         if (!tag) {
                             bu.send(msg, 'That ccommand doesn\'t exist!');
                             break;
                         }
-                        author = await r.table('user').get(tag.author).run();
-                        if (author.id != msg.author.id) {
-                            bu.send(msg, 'You don\'t own that custom command!');
-                            break;
-                        }
-
-                        if (words[3])
-                            authorizer = await bu.getUser(msg, words[3]);
-                        if (!authorizer) authorizer = msg.author.id;
+                        let author = await r.table('user').get(tag.author).run();
                         
-                        await bu.ccommand.setauthorizer(msg.channel.guild.id, title, authorizer.id);
-                        bu.send(msg, `✅ The tag \`${tag.name}\` by **${author.username}#${author.discriminator}** ` +
-                            `is now authorized by **${authorizer.username}#${authorizer.discriminator}**. ✅`);
+                        await bu.ccommand.setauthorizer(msg.channel.guild.id, title, msg.author.id);
+                        bu.send(msg, `✅ You are now the authorizer of the ccommand \`${title}\` owned ` +
+                                `by **${author.username}#${author.discriminator}** ✅`);
                     } else
                         bu.send(msg, `Not enough arguments! Usage is: \`ccommand setauthorizer <name> [user]\`.`);
                     break;

--- a/src/dcommands/ccommand.js
+++ b/src/dcommands/ccommand.js
@@ -689,6 +689,7 @@ class CcommandCommand extends BaseCommand {
                 case 'setauthorizer':
                     if (words.length > 2) {
                         let authorizer, author;
+                        title = filterTitle(words[2]);
                         tag = await bu.ccommand.get(msg.channel.guild.id, title);
                         if (!tag) {
                             bu.send(msg, 'That ccommand doesn\'t exist!');
@@ -699,8 +700,7 @@ class CcommandCommand extends BaseCommand {
                             bu.send(msg, 'You don\'t own that custom command!');
                             break;
                         }
-                        
-                        title = filterTitle(words[2]);
+
                         if (words[3])
                             authorizer = await bu.getUser(msg, words[3]);
                         if (!authorizer) authorizer = msg.author.id;

--- a/src/dcommands/ccommand.js
+++ b/src/dcommands/ccommand.js
@@ -11,6 +11,11 @@ const subcommands = [
         desc: 'Displays the name of the custom command\'s author'
     },
     {
+        name: 'setauthorizer',
+        args: '<name> [authorizer]',
+        desc: 'Set the custom command\'s authorizer'
+    },
+    {
         name: 'cooldown',
         args: '<name> [time]',
         desc: 'Sets the cooldown of a ccommand, in milliseconds. Cooldowns must be greater than 500ms'
@@ -680,6 +685,31 @@ class CcommandCommand extends BaseCommand {
                     } else {
                         bu.send(msg, this.info);
                     }
+                    break;
+                case 'setauthorizer':
+                    if (words.length > 2) {
+                        let authorizer, author;
+                        tag = await bu.ccommand.get(msg.channel.guild.id, title);
+                        if (!tag) {
+                            bu.send(msg, 'That ccommand doesn\'t exist!');
+                            break;
+                        }
+                        author = await r.table('user').get(tag.author).run();
+                        if (author !== msg.author.id) {
+                            bu.send(msg, 'You don\'t own that custom command!');
+                            break;
+                        }
+                        
+                        title = filterTitle(words[2]);
+                        if (words[3])
+                            authorizer = await bu.getUser(msg, words[3]);
+                        if (!authorizer) authorizer = msg.author.id;
+                        
+                        await bu.ccommand.setauthorizer(msg.channel.guild.id, title, authorizer.id);
+                        bu.send(msg, `✅ The tag \`${tag.name}\` by **${author.username}#${author.discriminator}** ` +
+                            `is now authorized by **${authorizer.username}#${authorizer.discriminator}**. ✅`);
+                    } else
+                        bu.send(msg, `Not enough arguments! Usage is: \`ccommand setauthorizer <name> [user]\`.`);
                     break;
                 case 'author':
                 case 'owner':

--- a/src/utils/database.js
+++ b/src/utils/database.js
@@ -132,6 +132,21 @@ bu.ccommand = {
         r.table('guild').get(guildid).replace(storedGuild).run();
         return;
     },
+    setauthorizer: async function (guildid, key, authorizer) {
+        let storedGuild = await bu.getGuild(guildid);
+        key = key.toLowerCase();
+        if (!storedGuild || !storedGuild.ccommands[key]) return false;
+        
+        storedGuild.ccomands[key].authorizer = authorizer;
+        r.table('guild').get(guildid).replace(storedGuild).run();
+        return true;
+    },
+    getauthorizer: async function (guildid, key) {
+        let storedGuild = await bu.getGuild(guildid);
+
+        if (!storedGuild || !storedGuild.ccommands[key.toLowerCase()]) return undefined;
+        return storedGuild.ccommands[key.toLowerCase()].authorizer;
+    },
     sethelp: async function (guildid, key, help) {
         let storedGuild = await bu.getGuild(guildid);
 

--- a/src/utils/database.js
+++ b/src/utils/database.js
@@ -137,7 +137,7 @@ bu.ccommand = {
         key = key.toLowerCase();
         if (!storedGuild || !storedGuild.ccommands[key]) return false;
         
-        storedGuild.ccomands[key].authorizer = authorizer;
+        storedGuild.ccommands[key].authorizer = authorizer;
         r.table('guild').get(guildid).replace(storedGuild).run();
         return true;
     },


### PR DESCRIPTION
Add a way for cc's owner to change the authorizer of the custom command with just a subcommand.

- [x] Update the `bu.ccommand` object to include a `setauthorizer()` method
- [x] Update the `bu.ccommand` object to include a `getauthorizer()` method
- [x] Update the `ccommand` to include a subcommand in order to change the authorizer