### PR TITLE
Handle provided empty condition

### DIFF
--- a/src/tags/waitmessage.js
+++ b/src/tags/waitmessage.js
@@ -92,7 +92,7 @@ module.exports =
             }
 
             // parse check code
-            if (args[2]) {
+            if (args[2] && args[2] !== "") {
                 checkBBTag = args[2];
             } else {
                 checkBBTag = bbengine.parse("true").bbtag;

--- a/src/tags/waitreact.js
+++ b/src/tags/waitreact.js
@@ -74,7 +74,7 @@ module.exports =
             }
 
             // parse check code
-            if (args[3]) {
+            if (args[3] && args[3] !== "") {
                 checkBBTag = args[3];
             } else {
                 checkBBTag = bbengine.parse("true").bbtag;


### PR DESCRIPTION
Fixes #199 

Update the check statement for the `condition` optional argument to include the case where it could be an empty string within:

- [x] `waitmessage.js` subtag where the BBTag code is stored in `args[2]` ([7851b71](https://github.com/blargbot/blargbot/commit/7851b7130a1620e446735c647e5b2df9baf62643))
- [x] `waitreact.js` subtag where the BBTag code is stored in `args[3]`  ([7851b71](https://github.com/blargbot/blargbot/commit/7851b7130a1620e446735c647e5b2df9baf62643))