### PR TITLE
Add prefix to ccommands and tags when added to the context cache to prevent conflicts

### DIFF
--- a/src/tags/exec.js
+++ b/src/tags/exec.js
@@ -20,7 +20,7 @@ module.exports =
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenDefault(async function (subtag, context, args) {
-            let tag = await context.getCached(args[0], key => r.table('tag').get(key).run());
+            let tag = await context.getCached(`tag_${args[0].toLowerCase()}`, key => r.table('tag').get(key).run());
 
             if (tag == null)
                 return Builder.util.error(subtag, context, 'Tag not found: ' + args[0]);

--- a/src/tags/exec.js
+++ b/src/tags/exec.js
@@ -20,7 +20,7 @@ module.exports =
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenDefault(async function (subtag, context, args) {
-            let tag = await context.getCached(`tag_${args[0].toLowerCase()}`, key => r.table('tag').get(key).run());
+            let tag = await context.getCached(`tag_${args[0]}`, key => r.table('tag').get(key).run());
 
             if (tag == null)
                 return Builder.util.error(subtag, context, 'Tag not found: ' + args[0]);

--- a/src/tags/exec.js
+++ b/src/tags/exec.js
@@ -20,7 +20,7 @@ module.exports =
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenDefault(async function (subtag, context, args) {
-            let tag = await context.getCached(`tag_${args[0]}`, key => r.table('tag').get(key).run());
+            let tag = await context.getCached(`tag_${args[0]}`, () => r.table('tag').get(args[0]).run());
 
             if (tag == null)
                 return Builder.util.error(subtag, context, 'Tag not found: ' + args[0]);

--- a/src/tags/execcc.js
+++ b/src/tags/execcc.js
@@ -20,7 +20,7 @@ module.exports =
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenDefault(async function (subtag, context, args) {
             let ccommand = await context.getCached(`cc_${args[0].toLowerCase()}`,
-                async key => (await bu.getGuild(context.guild.id)).ccommands[key]);
+                async () => (await bu.getGuild(context.guild.id)).ccommands[args[0]]);
 
             if (ccommand == null)
                 return Builder.util.error(subtag, context, 'CCommand not found: ' + args[0]);

--- a/src/tags/execcc.js
+++ b/src/tags/execcc.js
@@ -19,7 +19,7 @@ module.exports =
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenDefault(async function (subtag, context, args) {
-            let ccommand = await context.getCached(args[0].toLowerCase(),
+            let ccommand = await context.getCached(`cc_${args[0].toLowerCase()}`,
                 async key => (await bu.getGuild(context.guild.id)).ccommands[key]);
 
             if (ccommand == null)


### PR DESCRIPTION
- Edit `{exec}` subtag to add `tag_` prefix when adding a public tag to the context cache ([f895bfd](https://github.com/blargbot/blargbot/commit/f895bfdd63a678b37c6ad883152d3f544a67245d))
- Edit `{execcc}` subtag to add `cc_` prefix when adding a ccommand to the context cache ([1b0abe7](https://github.com/blargbot/blargbot/commit/1b0abe7beef07b833b1ff3cdbac33163c5139d70))

Both to prevent conflicts when custom commands and public tags are using each other and encounter a `getCached` conflict.

An example of this issue would be the **colorme** cc calling the **colourme** cc which contains `{exec;colourme;{args}}`. What happens when **colorme** is executed:
- it adds the **colourme** ccommand to the context's cache,
- it checks for the **colourme** cached value, finds one (which is the ccommand, not the tag which still needs to be added but will not),
- it executes the usertag with the provided context not having the public tag in it.

![image](https://user-images.githubusercontent.com/32441291/82103644-183ccf80-9714-11ea-8900-19d51d279dfb.png)


### Thanks to RagingLink#9469 for the issue breakdown and research.