### PR TITLE
Feature/everyone-mention-subtag

### DIFF
--- a/src/structures/bbtag/Context.js
+++ b/src/structures/bbtag/Context.js
@@ -206,7 +206,7 @@ class Context {
                     let disableEveryone = true;
                     if (this.isCC) {
                         let s = await r.table('guild').get(this.msg.guild.id);
-                        disableEveryone = s.settings.disableeveryone === true;
+                        disableEveryone = s.settings.disableeveryone === true || !this.state.allowedMentions.everybody;
                     }
                     let response = await bu.send(this.msg,
                         {

--- a/src/tags/everyone.js
+++ b/src/tags/everyone.js
@@ -1,30 +1,31 @@
-/*
- * @Author: stupid cat
- * @Date: 2017-05-07 18:38:55
- * @Last Modified by: stupid cat
- * @Last Modified time: 2017-10-19 18:12:29
+/**
+ * @Author: RagingLink 
+ * @Date: 2020-05-26 11:32:51
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2020-05-26 11:40:57
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
- */
+*/
 
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.APITag('everyone')
+    Builder.APITag('everyonemention')
+        .withAlias('everyone')
         .withArgs(a => [a.optional('enabled')])
         .withDesc(
             'Returns the mention of `@everyone`.\n' +
-            'If `enabled` is `false` it will return a non-pinging `@everyone`, defaults to `true`'
+            'If `enabled` is `false` it will return a non-pinging `@everyone`, defaults to `true`.'
         )
         .withExample(
-            '{everyone}',
+            '{everyonemention}',
             '@everyone'
         )
         .whenArgs('0-1', async function (subtag, context, args) {
             let enabled = bu.parseBoolean(args[0], true);
             context.state.allowedMentions.everybody = enabled;
+
             return "@everyone";
         })
         .whenDefault(Builder.errors.tooManyArguments)
         .build();
-        

--- a/src/tags/everyone.js
+++ b/src/tags/everyone.js
@@ -1,0 +1,30 @@
+/*
+ * @Author: stupid cat
+ * @Date: 2017-05-07 18:38:55
+ * @Last Modified by: stupid cat
+ * @Last Modified time: 2017-10-19 18:12:29
+ *
+ * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
+ */
+
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.BotTag('everyone')
+        .withArgs(a => [a.optional('enabled')])
+        .withDesc(
+            'Returns the mention of `@everyone`.\n' +
+            'If `enabled` is `false` it will return a non-pinging `@everyone`, defaults to `true`'
+        )
+        .withExample(
+            '{everyone}',
+            '@everyone'
+        )
+        .whenArgs('0-1', async function (subtag, context, args) {
+            let enabled = bu.parseBoolean(args[0], true);
+            context.state.allowedMentions.everybody = enabled;
+            return "@everyone";
+        })
+        .whenDefault(Builder.errors.tooManyArguments)
+        .build();
+        

--- a/src/tags/everyone.js
+++ b/src/tags/everyone.js
@@ -10,7 +10,7 @@
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
-    Builder.BotTag('everyone')
+    Builder.APITag('everyone')
         .withArgs(a => [a.optional('enabled')])
         .withDesc(
             'Returns the mention of `@everyone`.\n' +

--- a/src/tags/send.js
+++ b/src/tags/send.js
@@ -49,7 +49,7 @@ module.exports =
                 let disableEveryone = true;
                 if (context.isCC) {
                     let s = await r.table('guild').get(context.msg.guild.id);
-                    disableEveryone = s.settings.disableeveryone === true;
+                    disableEveryone = s.settings.disableeveryone === true || !context.state.allowedMentions.everybody;
                 }
                 let sent = await bu.send(channel.id, {
                     content: message,


### PR DESCRIPTION
Add a new **everyone** subtag to give more consistency and customization to the allowedMentions object. Just how **rolemention** returns a mention that pings the role, **everyone** would return an everyone mention that pings everyone. Attempts to ping `@everyone` without this subtag will result in it not pinging everyone.
The syntax of this subtag would be `{everyone;[enabled]}`. If `[enabled]` is `false` it will output `@everyone` which does not ping everyone.

**Added**
- `{everyone}` subtag [c02333f](https://github.com/blargbot/blargbot/commit/c02333f752318702d975f12e7d6d8ad86987ab0e)

**Changed**
- `disableEveryone` is now dependent on `allowedMentions` in `{send}` and `Context.sendOutput()` [6ca498f](https://github.com/blargbot/blargbot/commit/6ca498f029c817365a339c5c9fe8e1819b929ae4)