### PR TITLE
Fixed .hasPerm() not working with roleID

### DIFF
--- a/src/utils/generic.js
+++ b/src/utils/generic.js
@@ -240,7 +240,7 @@ bu.hasPerm = async (msg, perm, quiet, override = true) => {
                 role = getId(perm);
                 if (role === null) return false;
             };
-            Array.isArray(role) ?
+            return Array.isArray(role) ?
                 role.indexOf(m.id) > -1 :
                 m.id == role;
         }


### PR DESCRIPTION
Fixes #205 
Inside `bu.hasPerm()` there is no `return Boolean` statement if the `perm` array doesn't contain a rolename, it does check and pushes roleID's to the `role` array, but it doesn't actually return anything.

This results in users not being able to provide role ID's/mentions to command requirements, as they won't return `true` inside `bu.hasPerm()`

**Added:**
- `return` statement before the boolean [31f3f41](https://github.com/blargbot/blargbot/commit/31f3f41c571a787e733955677ca9fcb8183a7f75)