### PR TITLE
Added flag so users are able to remove usernames from b!names

### DIFF
--- a/src/dcommands/names.js
+++ b/src/dcommands/names.js
@@ -8,18 +8,40 @@ class NamesCommand extends BaseCommand {
             category: bu.CommandType.GENERAL,
             usage: 'names [user] [flags]',
             info: 'Returns the names that I\'ve seen the specified user have in the past 30 days.',
-            flags: [{ flag: 'a', word: 'all', desc: 'Gets all the names.' },
-            {
-                flag: 'v',
-                word: 'verbose',
-                desc: 'Gets more information about the retrieved names.'
-            }]
+            flags: [
+                {
+                    flag: 'a',
+                    word: 'all',
+                    desc: 'Gets all the names.'
+                },
+                {
+                    flag: 'v',
+                    word: 'verbose',
+                    desc: 'Gets more information about the retrieved names.'
+                },
+                {
+                    flag: 'r',
+                    word: 'remove',
+                    desc: 'Removes all your usernames from the database.'
+                }
+            ]
         });
     }
 
     async execute(msg, words, text) {
         let input = bu.parseInput(this.flags, words);
         let user;
+        if (input.r) {
+            user = msg.author;
+            let storedUser = bu.getCachedUser(user.id);
+            let updatedUser = { usernames: [] };
+            if (storedUser.usernames.length > 0 ) {
+                await r.table('user').get(user.id).update(updatedUser).run(); 
+                return bu.send(msg, `Succesfully removed ${storedUser.usernames.length} username${storedUser.usernames.length > 1 ? 's' : ''}.`);
+            } else {
+                return bu.send(msg, 'No usernames could be removed!')
+            }
+        }
         if (input.undefined.length == 0) {
             user = msg.author;
         } else {

--- a/src/dcommands/names.js
+++ b/src/dcommands/names.js
@@ -23,6 +23,11 @@ class NamesCommand extends BaseCommand {
                     flag: 'r',
                     word: 'remove',
                     desc: 'Removes all your usernames from the database.'
+                },
+                {
+                    flag: 'y',
+                    word: 'yes',
+                    desc: 'Bypasses the confirmation when removing usernames.'
                 }
             ]
         });
@@ -33,14 +38,62 @@ class NamesCommand extends BaseCommand {
         let user;
         if (input.r) {
             user = msg.author;
-            let storedUser = bu.getCachedUser(user.id);
+            let storedUser = await bu.getCachedUser(user.id);
             let updatedUser = { usernames: [] };
-            if (storedUser.usernames.length > 0 ) {
-                await r.table('user').get(user.id).update(updatedUser).run(); 
-                return bu.send(msg, `Succesfully removed ${storedUser.usernames.length} username${storedUser.usernames.length > 1 ? 's' : ''}.`);
-            } else {
-                return bu.send(msg, 'No usernames could be removed!')
+            if (!storedUser.usernames || storedUser.usernames.length == 0)
+                return bu.send(msg, 'You have no usernames to remove!');
+
+            if (input.a) {
+                let prompt, response;
+
+                if (!input.y) {
+                    prompt = await bu.createPrompt(msg, `Are you sure you want to remove ${storedUser.usernames.length} username${storedUser.usernames.length > 1 ? 's' : ''}?` +
+                        `\nType \`yes\` or anything else to cancel`, null, 60000);
+                    response = await prompt.response || {};
+                }
+                if (!response || bu.parseBoolean(response.content)) {
+                    await r.table('user').get(user.id).update(updatedUser).run();
+                    bu.send(msg, `Succesfully removed ${storedUser.usernames.length} username${storedUser.usernames.length > 1 ? 's' : ''}.`);
+                } else {
+                    bu.send(msg, `Removal cancelled.`)
+                }
+                if (prompt.prompt)
+                    await bot.deleteMessage(prompt.prompt.channel.id, prompt.prompt.id);
+                return;
+            } else if (input.r.length == 0) {
+                //lookup
+                let matches = storedUser.usernames.map((u, i) => { return { content: u.name, value: i } });
+                let lookup = await bu.createLookup(msg, 'username', matches);
+                if (await lookup == null)
+                    return;
+                let removedUsername = storedUser.usernames.splice(lookup, 1)[0];
+                await r.table('user').get(user.id).update(storedUser).run();
+                return bu.send(msg, `Succesfully removed **${removedUsername}**!`);
+            } else if (input.r.length > 0) {
+                //filter
+                let name = input.r.join(' ');
+                let filteredUsers = storedUser.usernames.filter(u => !(u.name.toLowerCase().includes(name)));
+                if (filteredUsers.length == storedUser.usernames.length)
+                    return bu.send(msg, `No usernames found!`);
+                let prompt, response;
+
+                if (!input.y) {
+                    prompt = await bu.createPrompt(msg, `Are you sure you want to remove ${storedUser.usernames.length - filteredUsers.length} username${storedUser.usernames.length - filteredUsers.length > 1 ? 's' : ''}?` +
+                        `\nType \`yes\` or anything else to cancel`, null, 60000);
+                    response = await prompt.response || {};
+                }
+                if (!response || bu.parseBoolean(response.content)) {
+                    await r.table('user').get(user.id).update({ usernames: filteredUsers }).run();
+                    await bu.send(msg, `Succesfully removed ${storedUser.usernames.length - filteredUsers.length} username${storedUser.usernames.length - filteredUsers.length > 1 ? 's' : ''}.`);
+                } else {
+                    await bu.send(msg, `OK, not removing your usernames!`);
+                }
+                if (response)
+                    await bot.deleteMessage(prompt.prompt.channel.id, prompt.prompt.id);
+                return;
             }
+
+
         }
         if (input.undefined.length == 0) {
             user = msg.author;

--- a/src/dcommands/names.js
+++ b/src/dcommands/names.js
@@ -45,19 +45,19 @@ class NamesCommand extends BaseCommand {
                 let prompt, response;
                 if (!input.a)
                     let name = input.r.join(' ');
-                let filteredUsers = input.a ? [] : storedUser.usernames.filter(u => !(u.name.toLowerCase().includes(name)));
+                let filteredUserNames = input.a ? [] : storedUser.usernames.filter(u => !(u.name.toLowerCase().includes(name)));
                 
-                if (filteredUsers.length === storedUser.usernames.length)
+                if (filteredUserNames.length === storedUser.usernames.length)
                     return bu.send(msg, `No usernames found!`);
                 
                 if (!input.y) {
-                    prompt = await bu.createPrompt(msg, `Are you sure you want to remove ${storedUser.usernames.length - filteredUsers.length} username${storedUser.usernames.length - filteredUsers.length > 1 ? 's' : ''}?` +
+                    prompt = await bu.createPrompt(msg, `Are you sure you want to remove ${storedUser.usernames.length - filteredUserNames.length} username${storedUser.usernames.length - filteredUserNames.length > 1 ? 's' : ''}?` +
                         `\nType \`yes\` or anything else to cancel`, null, 60000);
                     response = await prompt.response || {};
                 }
                 if ((response && bu.parseBoolean(response.content)) || input.y) {
-                    await r.table('user').get(user.id).update({usernames : filteredUsers}).run();
-                    await bu.send(msg, `Succesfully removed ${storedUser.usernames.length - filteredUsers.length} username${storedUser.usernames.length - filteredUsers.length > 1 ? 's' : ''}.`);
+                    await r.table('user').get(user.id).update({usernames : filteredUserNames}).run();
+                    await bu.send(msg, `Succesfully removed ${storedUser.usernames.length - filteredUserNames.length} username${storedUser.usernames.length - filteredUserNames.length > 1 ? 's' : ''}.`);
                 } else {
                     await bu.send(msg, `OK, not removing your usernames!`)
                 }
@@ -71,7 +71,7 @@ class NamesCommand extends BaseCommand {
                     return;
                 let removedUsername = storedUser.usernames.splice(lookup, 1)[0];
                 await r.table('user').get(user.id).update(storedUser).run();
-                return bu.send(msg, `Succesfully removed **${removedUsername}**!`);
+                return bu.send(msg, `Succesfully removed username **${removedUsername}**!`);
             };
         };
         if (input.undefined.length == 0) {

--- a/src/dcommands/names.js
+++ b/src/dcommands/names.js
@@ -22,7 +22,7 @@ class NamesCommand extends BaseCommand {
                 {
                     flag: 'r',
                     word: 'remove',
-                    desc: 'Removes all your usernames from the database.'
+                    desc: 'Removes the specified username from the database, or all usernames if used with the `all` flag.'
                 },
                 {
                     flag: 'y',
@@ -72,8 +72,8 @@ class NamesCommand extends BaseCommand {
                 let removedUsername = storedUser.usernames.splice(lookup, 1)[0];
                 await r.table('user').get(user.id).update(storedUser).run();
                 return bu.send(msg, `Succesfully removed username **${removedUsername}**!`);
-            };
-        };
+            }
+        }
         if (input.undefined.length == 0) {
             user = msg.author;
         } else {

--- a/src/utils/generic.js
+++ b/src/utils/generic.js
@@ -612,8 +612,8 @@ bu.getUser = async function (msg, name, args = {}) {
             return lookupResponse;
         } else {
             return null;
-        };
-    };
+        }
+    }
 };
 
 bu.getMessage = async function (channelId, messageId) {
@@ -678,8 +678,8 @@ bu.getRole = async function (msg, name, args = {}) {
             return lookupResponse;
         } else {
             return null;
-        };
-    };
+        }
+    }
 };
 
 bu.getMessage = async function (channelId, messageId) {

--- a/src/utils/generic.js
+++ b/src/utils/generic.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 19:22:33
  * @Last Modified by: RagingLink
- * @Last Modified time: 2020-06-10 22:15:59
+ * @Last Modified time: 2020-06-11 16:58:11
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -240,7 +240,7 @@ bu.hasPerm = async (msg, perm, quiet, override = true) => {
                 role = getId(perm);
                 if (role === null) return false;
             };
-            return Array.isArray(role) ?
+            Array.isArray(role) ?
                 role.indexOf(m.id) > -1 :
                 m.id == role;
         }
@@ -602,21 +602,18 @@ bu.getUser = async function (msg, name, args = {}) {
     } else if (userList.length == 0) {
         if (!args.quiet && !args.suppress) {
             if (args.onSendCallback) args.onSendCallback();
-            bu.send(msg, `No users found${args.label ? ' in ' + args.label : ''}.`);
+            await bu.send(msg, `No users found${args.label ? ' in ' + args.label : ''}.`);
         }
         return null;
     } else {
         if (!args.quiet) {
             let matches = userList.map(m => { return { content: `${m.user.username}#${m.user.discriminator} - ${m.user.id}`, value: m.user } })
             let lookupResponse = await bu.createLookup(msg, 'user', matches, args);
-            if (lookupResponse == null)
-                return null;
             return lookupResponse;
-            
         } else {
             return null;
-        }
-    }
+        };
+    };
 };
 
 bu.getMessage = async function (channelId, messageId) {
@@ -678,13 +675,11 @@ bu.getRole = async function (msg, name, args = {}) {
         if (!args.quiet) {
             let matches = roleList.map(r => { return { content: `${r.name} - ${r.color.toString(16)} (${r.id})`, value: r } });
             let lookupResponse = await bu.createLookup(msg, 'role', matches, args);
-            if (lookupResponse == null)
-                return null;
             return lookupResponse;
         } else {
             return null;
-        }
-    }
+        };
+    };
 };
 
 bu.getMessage = async function (channelId, messageId) {
@@ -1864,23 +1859,19 @@ bu.createLookup = async function (msg, type, matches, args = {}) {
     let moreLookup = lookupList.length < matches.length ? `...and ${matches.length - lookupList.length}more.\n` : '';
     try {
         if (args.onSendCallback) args.onSendCallback();
-        let query = await bu.createQuery(msg, `Multiple ${type}s found! Please select one from the list.\`\`\`prolog
-${outputString}${moreLookup}--------------------
-C.cancel query
-\`\`\`
-**${bu.getFullName(msg.author)}**, please type the number of the ${type} you wish to select below, or type \`c\` to cancel. This query will expire in 5 minutes.
-`,
-            (msg2) => {
-                if (msg2.content.toLowerCase() == 'c' || (parseInt(msg2.content) < lookupList.length + 1 && parseInt(msg2.content) >= 1)) {
-                    return true;
-                } else return false;
+        let query = await bu.createQuery(msg, `Multiple ${type}s found! Please select one from the list.\`\`\`prolog` +
+            `\n${outputString}${moreLookup}--------------------` +
+            `\nC.cancel query\`\`\`` +
+            `\n**${bu.getFullName(msg.author)}**, please type the number of the ${type} you wish to select below, or type \`c\` to cancel. This query will expire in 5 minutes.`
+            ,(msg2) => {
+                return msg2.content.toLowerCase() === 'c' || (parseInt(msg2.content) < lookupList.length + 1 && parseInt(msg2.content) >= 1)
             }, undefined, args.label, args.suppress);
         let response = await query.response;
-        if (response.content.toLowerCase() == 'c') {
+        if (response.content.toLowerCase() === 'c') {
             await bot.deleteMessage(query.prompt.channel.id, query.prompt.id);
             if (!args.suppress) {
                 if (args.onSendCallback) args.onSendCallback();
-                bu.send(msg, `Query canceled${args.label ? ' in ' + args.label : ''}.`);
+                await bu.send(msg, `Query canceled${args.label ? ' in ' + args.label : ''}.`);
             }
             return null;
         } else {


### PR DESCRIPTION
Currently it is not possible to delete/remove usernames from the database. I updated the command to allow users to delete this data by themselves.

The main reason for this to be implemented is to resolve privacy issues mentioned [here](https://discordapp.com/channels/194232473931087872/238131984017260546/719478282525081620)

**Added:**
- -r/--remove flag in `b!names` that removes all username records in the db [
9408c3e](https://github.com/blargbot/blargbot/commit/9408c3ed1b76e05f7785fad17175804c252684e6)