### PR TITLE
Added buffer functionality for webhook

### DIFF
--- a/src/tags/send.js
+++ b/src/tags/send.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:57:04
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-10-13 11:14:44
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2020-06-28 20:26:07
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -14,6 +14,7 @@ module.exports =
         .withArgs(a => [a.require('channel'), a.require([a.optional('message'), a.optional('embed')]), a.optional('file'), a.optional('filename')])
         .withDesc('Sends `message` and `embed` to `channel`, and returns the message ID. `channel` is either an ID or channel mention. ' +
             'At least one out of `message` and `embed` must be supplied.\nIf `file` is provided, `filename` will default to `file.txt`.\n' +
+            'If `file` starts with `buffer:`, the following text will be parsed as base64 to a raw buffer.' +
             'Please note that `embed` is the JSON for an embed object, don\'t put the `{embed}` subtag there, as nothing will show')
         .withExample(
             '{send;#channel;Hello!;{embedbuild;title:You\'re cool}}',

--- a/src/tags/send.js
+++ b/src/tags/send.js
@@ -14,7 +14,7 @@ module.exports =
         .withArgs(a => [a.require('channel'), a.require([a.optional('message'), a.optional('embed')]), a.optional('file'), a.optional('filename')])
         .withDesc('Sends `message` and `embed` to `channel`, and returns the message ID. `channel` is either an ID or channel mention. ' +
             'At least one out of `message` and `embed` must be supplied.\nIf `file` is provided, `filename` will default to `file.txt`.\n' +
-            'If `file` starts with `buffer:`, the following text will be parsed as base64 to a raw buffer.' +
+            'If `file` starts with `buffer:`, the following text will be parsed as base64 to a raw buffer.\n' +
             'Please note that `embed` is the JSON for an embed object, don\'t put the `{embed}` subtag there, as nothing will show')
         .withExample(
             '{send;#channel;Hello!;{embedbuild;title:You\'re cool}}',

--- a/src/tags/webhook.js
+++ b/src/tags/webhook.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:57:04
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-08-30 10:59:35
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2020-06-28 20:18:43
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -24,7 +24,8 @@ module.exports =
         .withDesc('Executes a webhook. The `embed` must be provided in a raw JSON format, properly escaped for BBTag. ' +
         'A simple escaping utility can be accessed [here](https://rewrite.blargbot.xyz/v1escaper). ' +
         'You can find an easy tool to test out embeds [here](https://leovoel.github.io/embed-visualizer/). ' +
-        'Please assign your webhook credentials to private variables! Do not leave them in your code.')
+        'Please assign your webhook credentials to private variables! Do not leave them in your code.' +
+        'If `file` starts with `buffer:`, the following text will be parsed as base64 to a raw buffer.')
         .withExample(
         '{webhook;1111111111111111;t.OK-en;Hello!}',
         'In the webhook channel: Hello!'
@@ -43,6 +44,10 @@ module.exports =
             if (file) {
                 if (!filename) filename = 'file.txt';
                 file = { file, name: filename };
+
+                if (file.file.startsWith('buffer:')) {
+                    file.file = Buffer.from(file.file.substring(7), 'base64');
+                }
             }
 
             try {


### PR DESCRIPTION
`webhook` currently doesn't handle base64 text inside `file`, while other subtags with the `file` parameter do. This should really be made universal, and thus I extended webhook with it. 
Also added documentation for buffer: inside `webhook` and `send`, as currently only the `file` subtag mentions `buffer:`.

**Added**:
- buffer: functionality and documenation in webhook [7757737](https://github.com/blargbot/blargbot/commit/77577372f2d8fee2eb31699809413548c561b35a)
- Documentation of buffer: in `send` [27b40a5](https://github.com/blargbot/blargbot/commit/27b40a5e0fc82e0a41c45b0496beea8ac7b02e99)