### PR TITLE
Fixed arrays being stored as string with jset

### DIFF
--- a/src/tags/jsonset.js
+++ b/src/tags/jsonset.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:49:14
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-09-06 14:19:25
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2020-06-30 18:45:41
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -29,7 +29,10 @@ module.exports =
                 obj = '{}';
 
             let varname = undefined;
-
+            const deserializedTagArray = await bu.deserializeTagArray(value);
+            if (deserializedTagArray)
+                value = deserializedTagArray.v;
+            
             let arr = await bu.getArray(obj);
             if (arr && Array.isArray(arr.v)) {
                 obj = arr.v;

--- a/src/tags/jsonset.js
+++ b/src/tags/jsonset.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 18:49:14
  * @Last Modified by: RagingLink
- * @Last Modified time: 2020-06-30 18:45:41
+ * @Last Modified time: 2020-06-30 19:59:24
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -30,7 +30,7 @@ module.exports =
 
             let varname = undefined;
             const deserializedTagArray = await bu.deserializeTagArray(value);
-            if (deserializedTagArray)
+            if (deserializedTagArray && !deserializedTagArray.n)
                 value = deserializedTagArray.v;
             
             let arr = await bu.getArray(obj);


### PR DESCRIPTION
Resolves [Airtable report](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwDg5WovcwMA9NIL/recDo2XJxNngfJCHi)

Todo:
- [ ] Properly handle input array as `obj`

**Added**:
- deserialization of array values [c2c8fb8](https://github.com/blargbot/blargbot/commit/c2c8fb89daa933cd8b6b5f11e81b052977b71fea)