### PR TITLE
New escapebbtag subtag

### DIFF
--- a/src/tags/escapebbtag.js
+++ b/src/tags/escapebbtag.js
@@ -2,7 +2,7 @@
  * @Author: RagingLink 
  * @Date: 2020-06-25 12:25:05
  * @Last Modified by: RagingLink
- * @Last Modified time: 2020-06-30 21:59:10
+ * @Last Modified time: 2021-05-21 00:05:34
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -14,7 +14,8 @@ module.exports =
         .withArgs(a => [a.require('code')])
         .withAlias('escape')
         .withDesc('Returns `code` without executing any BBtag inside it.\n' +
-            'This effectively returns the characters `{`,`}` and `;` as is, without the use of `{rb}`, `{lb}` and `{semi}`.')
+            'This effectively returns the characters `{`,`}` and `;` as is, without the use of `{rb}`, `{lb}` and `{semi}`.\n' +
+            '**NOTE**: Brackets inside `code` must come in pairs. A { *has to be* followed by a } somewhere and a } *has to have* a { before it')
         .withExample(
             '{escapebbtag;{set;~index;1}}',
             '{set;~index;1}'

--- a/src/tags/escapebbtag.js
+++ b/src/tags/escapebbtag.js
@@ -1,0 +1,27 @@
+/**
+ * @Author: RagingLink 
+ * @Date: 2020-06-25 12:25:05
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2020-06-30 21:59:10
+ *
+ * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
+ */
+
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.BotTag('escapebbtag')
+        .withArgs(a => [a.require('code')])
+        .withAlias('escape')
+        .withDesc('Returns `code` without executing any BBtag inside it.\n' +
+            'This effectively returns the characters `{`,`}` and `;` as is, without the use of `{rb}`, `{lb}` and `{semi}`.')
+        .withExample(
+            '{escapebbtag;{set;~index;1}}',
+            '{set;~index;1}'
+        )
+        .resolveArgs(-1)
+        .whenArgs(0, Builder.errors.notEnoughArguments)
+        .whenDefault(async (subtag, context, args) => {
+            return args.map(arg => arg.content).join(';');
+        })
+        .build();


### PR DESCRIPTION
New subtag `escapebbtag` with alias `escape`. This would provide an easy way of escaping BBtag code, without needing to use `{rb}`, `{lb}` and `{semi}`. This could be useful if you want to set a variable to something that you don't want to parse as BBtag when setting it (without using character escape subtags).
 Based on the following suggestions: [582](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwl0N62QIReJLMJv/reckvBdm7skJUgIUp), [549](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwl0N62QIReJLMJv/recGmj25ttQWk3VE3), [532](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwl0N62QIReJLMJv/recoukHUHMAm2dKa5), [160](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwl0N62QIReJLMJv/recjGBMJP02gWH0vf)

**Added**:
- escapebbtag subtag [459d18c](https://github.com/blargbot/blargbot/commit/459d18c415cb7987ac613b8534a65d1aed2c7572)