### PR TITLE
New map subtag for arrays

### DIFF
--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -474,6 +474,7 @@ const limits = {
 
             this.for = { loops: 1500 };
             this.foreach = { loops: 3000 };
+            this.map = { loops: 3000 };
 
             this.dump = { count: 5 };
         }
@@ -517,6 +518,7 @@ const limits = {
 
             this.for = { loops: 1500 };
             this.foreach = { loops: 3000 };
+            this.map = { loops: 3000 };
 
             this.dump = { count: 5 };
         }
@@ -562,6 +564,7 @@ const limits = {
 
             this.for = { loops: 1000 };
             this.foreach = { loops: 2000 };
+            this.map = { loops: 2000 };
 
             this.dump = { count: 5 };
         }
@@ -605,6 +608,7 @@ const limits = {
 
             this.for = { loops: 500 };
             this.foreach = { loops: 1000 };
+            this.map = { loops: 1000 };
 
             this.dump = { count: 5 };
         }

--- a/src/tags/map.js
+++ b/src/tags/map.js
@@ -23,7 +23,7 @@ module.exports =
             ' it will simply output the new array.'
         )
         .withExample(
-            '{set;~array;apples;oranges;pears}\n{map;~item;{get;~array};{upper;{get;~item}}',
+            '{map;~item;["apples","oranges","pears"];{upper;{get;~item}}}',
             '["APPLES","ORANGES","PEARS"]'
         )
         .resolveArgs(0, 1)

--- a/src/tags/map.js
+++ b/src/tags/map.js
@@ -2,7 +2,7 @@
  * @Author: RagingLink 
  * @Date: 2020-06-03 23:26:05
  * @Last Modified by: RagingLink
- * @Last Modified time: 2020-06-04 00:17:35
+ * @Last Modified time: 2020-07-17 22:17:35
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -34,14 +34,13 @@ module.exports =
                 array = Array.from(arr.v),
                 newArray = [];
             
-            //let remaining = context.state.limits.map || {loops : NaN};
-            for (const item of array) { //Avoid using Array.prototype.map() due to the inability to exit the loop in case of context.state.return
-                /*Loop logic maybe ? dunno what the limit of map should be tbh
-                remaining.loops--
+            let remaining = context.state.limits.map || {loops : NaN};
+            for (const item of array) {
+                remaining.loops--;
                 if (!(remaining.loops >= 0)) {
-                    result += Builder.errors.tooManyLoops(subtag, context);
+                    newArray.push(Builder.errors.tooManyLoops(subtag, context));
                     break;
-                }*/
+                }
                 await context.variables.set(varName, item);
                 newArray.push(await this.executeArg(subtag, args[2], context));
 

--- a/src/tags/map.js
+++ b/src/tags/map.js
@@ -1,0 +1,59 @@
+/**
+ * @Author: RagingLink 
+ * @Date: 2020-06-03 23:26:05
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2020-06-04 00:17:35
+ *
+ * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
+ */
+
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.ArrayTag('map')
+        .withArgs(a => [
+            a.require('variable'),
+            a.require('array'),
+            a.require('function')
+        ])
+        .withDesc('Provides a way to populate an array by executing a function on each of its elements,' +
+            ' more info [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)\n' +
+            'For every element in `array`, `variable` will be set and `function` will be executed. The output of `function`' +
+            ' will be the new value of the element. If `array` is a variable it will update the variable. Otherwise,' +
+            ' it will simply output the new array.'
+        )
+        .withExample(
+            '{set;~array;apples;oranges;pears}\n{map;~item;{get;~array};{upper;{get;~item}}',
+            '["APPLES","ORANGES","PEARS"]'
+        )
+        .resolveArgs(0, 1)
+        .whenArgs('0-2', Builder.errors.notEnoughArguments)
+        .whenArgs('3', async function (subtag, context, args) {
+            let varName = args[0],
+                arr = await bu.getArray(context, args[1]),
+                array = Array.from(arr.v),
+                newArray = [];
+            
+            //let remaining = context.state.limits.map || {loops : NaN};
+            for (const item of array) { //Avoid using Array.prototype.map() due to the inability to exit the loop in case of context.state.return
+                /*Loop logic maybe ? dunno what the limit of map should be tbh
+                remaining.loops--
+                if (!(remaining.loops >= 0)) {
+                    result += Builder.errors.tooManyLoops(subtag, context);
+                    break;
+                }*/
+                await context.variables.set(varName, item);
+                newArray.push(await this.executeArg(subtag, args[2], context));
+
+                if (context.state.return)
+                    break;
+            };
+
+            context.variables.reset(varName);
+            if (arr.n != null)
+                await context.variables.set(arr.n, newArray);
+            else
+                return bu.serializeTagArray(newArray);
+            
+        }).whenDefault(Builder.errors.tooManyArguments)
+        .build();


### PR DESCRIPTION
Created a map subtag that maps the input array and either returns the output array, or modifies the original array if a variable is provided. 

I'm still not sure if the limits are appropriate, currently `map` has the same limits as `foreach`, as code-wise they're very similar.

**Added**:
- Map subtag [693c1b0](https://github.com/blargbot/blargbot/commit/693c1b021751b28883712bbe297d1e76bf53ee54)
- Map limits [57c44fa](https://github.com/blargbot/blargbot/commit/57c44fab88072dc473ef2b91bb9392ecf1429d6d)