### PR TITLE
Support news and store channels in channeltype

### DIFF
--- a/src/tags/channeltype.js
+++ b/src/tags/channeltype.js
@@ -9,7 +9,7 @@
 
 const Builder = require('../structures/TagBuilder');
 
-const types = ['text', 'dm', 'voice', 'group-dm', 'category'];
+const types = ['text', 'dm', 'voice', 'group-dm', 'category', 'news', 'store'];
 
 module.exports =
     Builder.APITag('channeltype')


### PR DESCRIPTION
This adds the (relatively) new channeltypes `news` and `store` to `{channeltype}`.

**Added**:
- News and store channeltype [f2feb64](https://github.com/blargbot/blargbot/commit/f2feb64aa74ef77df7d1c2604d3bd2b305880d45)