### PR TITLE
JSON extensions

### DIFF
--- a/src/tags/jsonkeys.js
+++ b/src/tags/jsonkeys.js
@@ -1,0 +1,78 @@
+/*
+ * @Author: RagingLink
+ * @Date: 2020-07-17 19:24:32
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2020-09-11 21:25:15
+ *
+ * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
+ */
+
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.ArrayTag('jsonkeys')
+        .withAlias('jkeys')
+        .withArgs(a => [a.require('object'), a.optional('path')])
+        .withDesc('Retrieves all keys from provided JSON object.' + 
+        '`object` can be a JSON object, array, or string. If a string is provided, a variable with the same name will be used.\n' +
+        '`path` is a dot-noted series of properties.'
+        )
+        .withExample('{set;~json;{json;{"key": "value", "key2" : "value2"}}\n'
+            + '{jsonkeys;~json}', '["key","key2"]')
+        .whenArgs(0, Builder.errors.notEnoughArguments)
+        .whenArgs('1-2', async (subtag, context, args) => {
+            let obj = args[0],
+                path = args[1],
+                varname;
+
+            let arr = await bu.getArray(obj);
+            if (arr && Array.isArray(arr.v)) obj = arr.v;
+
+            try {
+                obj = JSON.parse(obj);
+            } catch (err) {
+                varname = obj;
+                let v = await context.variables.get(varname);
+                if (v) {
+                    if (typeof v === 'object') {
+                        obj = v;
+                    } else {
+                        try {
+                            obj = JSON.parse(v);
+                        } catch (err2) {
+                            obj = {};
+                        }
+                    }
+                } else obj = {};
+            }
+            if (typeof obj !== 'object' || obj === null) obj = {};
+            try {
+                if (path) {
+                    path = path.split('.');
+                    for (const part of path) {
+                        if (typeof obj === 'string') {
+                            try {
+                                obj = JSON.parse(obj);
+                            } catch (err) { }
+                        }
+
+                        if (typeof obj === 'object') {
+                            const keys = Object.keys(obj);
+                            if (keys.length === 2 && keys.includes('v') && keys.includes('n') && /^\d+$/.test(part)) {
+                                obj = obj.v;
+                            }
+                        }
+
+                        // intentionally let it error if undefined
+                        if (obj === undefined || obj.hasOwnProperty(part))
+                            obj = obj[part];
+                        else obj = undefined;
+                    }
+                }
+                return Object.keys(obj);
+            } catch (err) {
+                return Builder.errors.customError(subtag, context, err.message);
+            }
+        })
+        .whenDefault(Builder.errors.tooManyArguments)
+        .build();

--- a/src/tags/jsonkeys.js
+++ b/src/tags/jsonkeys.js
@@ -13,7 +13,7 @@ module.exports =
     Builder.ArrayTag('jsonkeys')
         .withAlias('jkeys')
         .withArgs(a => [a.require('object'), a.optional('path')])
-        .withDesc('Retrieves all keys from provided JSON object.' + 
+        .withDesc('Retrieves all keys from provided the JSON object. ' + 
         '`object` can be a JSON object, array, or string. If a string is provided, a variable with the same name will be used.\n' +
         '`path` is a dot-noted series of properties.'
         )

--- a/src/tags/jsonsort.js
+++ b/src/tags/jsonsort.js
@@ -1,0 +1,118 @@
+/**
+ * @Author: RagingLink 
+ * @Date: 2020-07-28 21:09:40
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2020-08-01 20:2 7:36
+ *
+ * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
+ */
+
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.ArrayTag('jsonsort')
+        .withAlias('jsort')
+        .withArgs(a => [a.require('array'), a.require('path'), a.optional('descending')])   
+        .withDesc('Sorts an array of objects based on on the provided `path`.\n' +
+            '`path` is a dot-noted series of properties.' +
+            'If `descending` is provided, sorts in descending order.\n' +
+            'If provided a variable, will modify the original `array`.'
+        ).withExample(
+            '{set;~array;{json;[\n  {"points" : 10, "name" : "Blargbot"},\n  {"points" : 3, "name" : "UNO"},\n' +
+            '  {"points" : 6, "name" : "Stupid cat"},\n  {"points" : 12, "name" : "Winner"}\n]}}\n' +
+            '{jsonstringify;{jsonsort;{slice;{get;~array};0};points};2}',
+            '[\n  "{\\"points\\":3,\\"name\\":\\"UNO\\"}",\n  "{\\"points\\":6,\\"name\\":\\"Stupid cat\\"}",' +
+            '\n  "{\\"points\\":10,\\"name\\":\\"Blargbot\\"}",\n  "{\\"points\\":12,\\"name\\":\\"Winner\\"}"\n]'
+        ).whenArgs('0-1', Builder.errors.notEnoughArguments)
+        .whenArgs('2-3', async (subtag, context, args) => {
+            let arr = await bu.getArray(context, args[0]),
+                path = args[1] ? args[1].split('.') : undefined;
+                descending = bu.parseBoolean(args[2]);
+            
+            if (!bu.isBoolean(descending))
+                descending = !!args[2];
+
+            if (arr == null || !Array.isArray(arr.v))
+                return Builder.errors.notAnArray(subtag, context);
+            if(!path) return Builder.errors.customError(subtag, context, 'No path provided');
+            //Map array with values of array[item][path]
+            let mappedArray = await Promise.all(arr.v.map(item => {
+                try {
+                    if (typeof item !== 'object')
+                        item = JSON.parse(item)
+                } catch (e) {
+                    item = {};
+                }
+                for (const part of path) {
+                    if (typeof item === 'string') {
+                        try {
+                            item = JSON.parse(item);
+                        } catch (err) { }
+                    }
+
+                    if (typeof item === 'object') {
+                        const keys = Object.keys(item);
+                        if (keys.length === 2 && keys.includes('v') && keys.includes('n') && /^\d+$/.test(part)) {
+                            item = item.v;
+                        }
+                    }
+                    if (item && item.hasOwnProperty(part)) {
+                        item = item[part];
+                    } else item = undefined;
+                } 
+                return item;
+            }));
+            //If there are any undefined values return an error stating at which index the 'faulty' object is and how many faulty there are
+            let undefinedItems = mappedArray.filter(v => v === undefined)
+            if (undefinedItems.length !== 0) {
+                return Builder.errors.customError(subtag, context, 'Cannot read property ' + path + ' at index ' + mappedArray.indexOf(undefined) + ', ' + undefinedItems.length + ' total failures' );
+            };
+            //Sort the array
+            arr.v = arr.v.sort((a, b) => {
+                if (typeof a !== 'object')
+                    a = JSON.parse(a)
+                if (typeof b !== 'object')
+                    b = JSON.parse(b);
+                //Value of path of a
+                for (const part of path) {
+                    if (typeof a === 'string') {
+                        try {
+                            a = JSON.parse(a);
+                        } catch (err) { }
+                    }
+
+                    if (typeof a === 'object') {
+                        const keys = Object.keys(a);
+                        if (keys.length === 2 && keys.includes('v') && keys.includes('n') && /^\d+$/.test(part)) {
+                            a = a.v;
+                        }
+                    }
+                    if (a.hasOwnProperty(part)) a = a[part];
+                }
+                //Value of path of b
+                for (const part of path) {
+                    if (typeof b === 'string') {
+                        try {
+                            b = JSON.parse(b);
+                        } catch (err) { }
+                    }
+
+                    if (typeof b === 'object') {
+                        const keys = Object.keys(b);
+                        if (keys.length === 2 && keys.includes('v') && keys.includes('n') && /^\d+$/.test(part)) {
+                            b = b.v;
+                        }
+                    }
+                    if (b.hasOwnProperty(part)) b = b[part];
+                }   
+                return bu.compare(a,b)
+            });
+            
+            if (descending) arr.v.reverse();
+
+            if (!arr.n)
+                return bu.serializeTagArray(arr.v);
+            await context.variables.set(arr.n, arr.v);
+
+        })
+        .build();

--- a/src/tags/jsonsort.js
+++ b/src/tags/jsonsort.js
@@ -13,8 +13,8 @@ module.exports =
     Builder.ArrayTag('jsonsort')
         .withAlias('jsort')
         .withArgs(a => [a.require('array'), a.require('path'), a.optional('descending')])   
-        .withDesc('Sorts an array of objects based on on the provided `path`.\n' +
-            '`path` is a dot-noted series of properties.' +
+        .withDesc('Sorts an array of objects based on the provided `path`.\n' +
+            '`path` is a dot-noted series of properties.\n' +
             'If `descending` is provided, sorts in descending order.\n' +
             'If provided a variable, will modify the original `array`.'
         ).withExample(

--- a/src/tags/jsonvalues.js
+++ b/src/tags/jsonvalues.js
@@ -1,0 +1,79 @@
+/*
+ * @Author: RagingLink
+ * @Date: 2020-07-17 19:40:32
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2020-09-11 21:24:47
+ *
+ * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
+ */
+
+const Builder = require("../structures/TagBuilder");
+
+module.exports =
+    Builder.ArrayTag('jsonvalues')
+        .withAlias('jvalues')
+        .withArgs(a => [a.require('object'), a.optional('path')])
+        .withDesc('Retrieves all values from provided object' +
+        '`object` can be a JSON object, array, or string. If a string is provided, a variable with the same name will be used.\n' +
+        '`path` is a dot-noted series of properties.'
+        )
+        .withExample('{set;~json;{json;{"key": "value", "key2" : "value2"}}\n'
+            + '{jsonvalues;~json}',
+            '["value","value2"]')
+        .whenArgs(0, Builder.errors.notEnoughArguments)
+        .whenArgs('1-2', async (subtag, context, args) => {
+            let obj = args[0],
+                path = args[1],
+                varname;
+
+            let arr = await bu.getArray(obj);
+            if (arr && Array.isArray(arr.v)) obj = arr.v;
+
+            try {
+                obj = JSON.parse(obj);
+            } catch (err) {
+                varname = obj;
+                let v = await context.variables.get(varname);
+                if (v) {
+                    if (typeof v === 'object') {
+                        obj = v;
+                    } else {
+                        try {
+                            obj = JSON.parse(v);
+                        } catch (err2) {
+                            obj = {};
+                        }
+                    }
+                } else obj = {};
+            }
+            if (typeof obj !== 'object' || obj === null) obj = {};
+            try {
+                if (path) {
+                    path = path.split('.');
+                    for (const part of path) {
+                        if (typeof obj === 'string') {
+                            try {
+                                obj = JSON.parse(obj);
+                            } catch (err) { }
+                        }
+
+                        if (typeof obj === 'object') {
+                            const keys = Object.keys(obj);
+                            if (keys.length === 2 && keys.includes('v') && keys.includes('n') && /^\d+$/.test(part)) {
+                                obj = obj.v;
+                            }
+                        }
+
+                        // intentionally let it error if undefined
+                        if (obj === undefined || obj.hasOwnProperty(part))
+                            obj = obj[part];
+                        else obj = undefined;
+                    }
+                }
+                return Object.values(obj);
+            } catch (err) {
+                return Builder.errors.customError(subtag, context, err.message);
+            }
+        })
+        .whenDefault(Builder.errors.tooManyArguments)
+        .build();

--- a/src/tags/jsonvalues.js
+++ b/src/tags/jsonvalues.js
@@ -13,7 +13,7 @@ module.exports =
     Builder.ArrayTag('jsonvalues')
         .withAlias('jvalues')
         .withArgs(a => [a.require('object'), a.optional('path')])
-        .withDesc('Retrieves all values from provided object' +
+        .withDesc('Retrieves all values from the provided object. ' +
         '`object` can be a JSON object, array, or string. If a string is provided, a variable with the same name will be used.\n' +
         '`path` is a dot-noted series of properties.'
         )


### PR DESCRIPTION
Allow users to access values and keys of objects programmatically with `jsonkeys` and `jsonvalues`. Implementation-wise, this is no different from `{json}` or `{jsonget}` (code is practically indifferent), but it returns (obviously) the values or keys of the object instead.
Also implemented `jsonsort` which sorts an array of objects based on properties in the objects.
**Added:**
- `jsonvalues` and `jsonkeys` [d7ae7f8](https://github.com/blargbot/blargbot/commit/d7ae7f82c2895d776a59025497e791a15872bd88)
- `jsonsort` [ab5c5e0](https://github.com/blargbot/blargbot/pull/222/commits/ab5c5e03288a80fe9e31ca9cbfd47b3ff578e013)

