### PR TITLE
Sort prefixes with longer prefixes first

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -60,7 +60,7 @@ async function handleUserMessage(msg, storedGuild) {
     };
     prefixes.push(config.discord.defaultPrefix, 'blargbot');
     prefixes.sort((a, b) => {
-        return a.length < b.length;
+        return b.length - a.length; //Sort descending
     });
     if (await handleBlacklist(msg, storedGuild)) return;
 


### PR DESCRIPTION
Sorts prefixes based on the length instead of `a.length < b.length`, this is done in descending order so in cases where a user has a blank prefix `""` it would always pick that one and render other prefixes practically useless (as blargbot tries to execute a command with the blank prefix)
In response to suggestion [689](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwWwUA753iEQqOo7/recsAvekO5oAM2YVQ?blocks=bipip3uBZFRPcSy3C)

**Changed:**
- Sorting function from `a.length < b.length` to `b.length - a.length` [a247b95](https://github.com/blargbot/blargbot/commit/a247b953db088f6a26b903163032912f5208d99c)