### PR TITLE
Replace br with newlines

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -571,7 +571,7 @@ function query(input) {
             else {
                 let content = bod.match(/<font size="2" face="Verdana" color=darkred>(.+)<\/font>/);
                 if (content)
-                    res(content[1].replace(/(\W)alice(\W)/gi, '$1blargbot$2'));
+                    res(content[1].replace(/(\W)alice(\W)/gi, '$1blargbot$2').replace(/<br>/gm, '\n'));
                 else res('Hi, I\'m blargbot! It\'s nice to meet you.');
             }
         });


### PR DESCRIPTION
Replace \<br\> with newlines.
In response to bug [687](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwjCMIsqe4FYzPlu/recYWDB09niUWwrHs?blocks=bipip3uBZFRPcSy3C)

**Added**:
- replacement method of br [0aead96](https://github.com/blargbot/blargbot/commit/0aead96bda11e8ad2f4f7e8dc8be6fc3e9f339b8)