### PR TITLE
Add zws character so blarg strips the beginning mention in cleverbot

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -583,7 +583,7 @@ async function handleCleverbot(msg) {
     var username = msg.channel.guild.members.get(bot.user.id).nick ?
         msg.channel.guild.members.get(bot.user.id).nick :
         bot.user.username;
-    var msgToSend = msg.cleanContent.replace(new RegExp('@' + username + ',?'), '').trim();
+    var msgToSend = msg.cleanContent.replace(new RegExp('@' + '\u200b' + username + ',?'), '').trim();
     bu.cleverbotStats++;
     updateStats();
     try {


### PR DESCRIPTION
As of Eris 14.0.0 they replace mentions with ` @' + '\u200b' + username` (changed in commit [13390b9](https://github.com/abalabahaha/eris/commit/13390b9b5328f57173b4a6ae4b2487ead9f1f386 "Escape more cleanContent mentions")). Since blargbot isn't checking for the zws character in the regex, the mention doesn't get stripped and results in random responses instead of the usual "Hi. My name is blargbot..." `
Examples: 
![image](https://user-images.githubusercontent.com/15198000/106399600-f4dcc080-6419-11eb-8466-95756cb12d44.png)

**Added**:
- `\u200b` to the Regex `Regexp('@' + username + ',?')/` [e8df93e](https://github.com/blargbot/blargbot/commit/e8df93ecc46cbe9ec31735abb68a7c1e9c86db85 "Add zws to stripped mention cleverbot")

