### PR TITLE
Fixed bug inside slowmode

### DIFF
--- a/src/dcommands/slowmode.js
+++ b/src/dcommands/slowmode.js
@@ -21,7 +21,7 @@ class SlowmodeCommand extends BaseCommand {
 
         time = Math.min(time, 120);
 
-        let channel = msg.channel.id;
+        let channel = msg.channel;
         if (input.c && /(\d+)/.test(input.c[0])) {
             let c = input.c[0].match(/(\d+)/)[1];
             let guild = bot.channelGuildMap[channel];


### PR DESCRIPTION
Defined `channel` as the Channel Object instead of the ID. 

This was probably looked over in commit [3fb692f](https://github.com/blargbot/blargbot/commit/3fb692ff2a01a13ca48bdaa5eaa76f50cd1d5d26) where `channel` was the ID.