### PR TITLE
Skip through the authorization screen if previously authorized

### DIFF
--- a/src/backend/main.js
+++ b/src/backend/main.js
@@ -61,7 +61,8 @@ e.init = () => {
         clientID: config.website.clientid,
         clientSecret: config.website.secret,
         callbackURL: config.website.callback,
-        scope: scopes
+        scope: scopes,
+        prompt : 'none'
     }, function (accessToken, refreshToken, profile, done) {
         process.nextTick(function () {
             return done(null, profile);


### PR DESCRIPTION
Something that personally annoys me is the fact I have to authorize blarg every day or so when using the tag IDE.
I'd like to see `prompt : 'none'` added to the [strategy used](https://github.com/blargbot/blargbot/blob/4d9d40a65efbf5986c073abd101d410bdb0645ff/src/backend/main.js#L60-L64) to allow for quicker authorization.

The `prompt : 'none'` is documented under [Authorization Code Grant](https://discord.com/developers/docs/topics/oauth2#authorization-code-grant).