### PR TITLE
Added support for flag names in exec and execcc

### DIFF
--- a/src/tags/exec.js
+++ b/src/tags/exec.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:37:16
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-07-11 11:34:03
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-05-11 18:50:57
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -45,13 +45,13 @@ module.exports =
                 case 1:
                     return await this.execTag(subtag, context, tag.content, '');
                 case 2:
-                    return await this.execTag(subtag, context, tag.content, args[1]);
+                    return await this.execTag(subtag, context, tag.content, args[1], tag.flags);
                 default:
                     let a = Builder.util.flattenArgArrays(args.slice(1));
-                    return await this.execTag(subtag, context, tag.content, '"' + a.join('" "') + '"');
+                    return await this.execTag(subtag, context, tag.content, '"' + a.join('" "') + '"', tag.flags);
             }
         })
-        .withProp('execTag', async function (subtag, context, tagContent, input) {
+        .withProp('execTag', async function (subtag, context, tagContent, input, flags) {
             if (context.state.stackSize >= 200) {
                 context.state.return = -1;
                 return Builder.util.error(subtag, context, 'Terminated recursive tag after ' + context.state.stackSize + ' execs.');
@@ -66,7 +66,7 @@ module.exports =
             }
 
             context.state.stackSize += 1;
-            let childContext = context.makeChild({ input });
+            let childContext = context.makeChild({ input, flags });
             if (tagContent != null)
                 result = await this.executeArg(subtag, tagContent, childContext);
             context.state.stackSize -= 1;

--- a/src/tags/execcc.js
+++ b/src/tags/execcc.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:37:21
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-06-04 11:39:51
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-05-11 18:54:06
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -46,11 +46,12 @@ module.exports =
                 case 1:
                     return TagManager.list['exec'].execTag(subtag, context, ccommand.content, '');
                 case 2:
-                    return TagManager.list['exec'].execTag(subtag, context, ccommand.content, args[1]);
+                    return TagManager.list['exec'].execTag(subtag, context, ccommand.content, args[1], ccommand.flags);
                 default:
                     let a = Builder.util.flattenArgArrays(args.slice(1));
-                    return TagManager.list['exec'].execTag(subtag, context, ccommand.content, '"' + a.join('" "') + '"');
+                    return TagManager.list['exec'].execTag(subtag, context, ccommand.content, '"' + a.join('" "') + '"', ccommand.flags);
             }
+            // ! This line can be removed as the 'default' case already returns
             return TagManager.list['exec'].execTag(subtag, context, ccommand.content, args[1] || '');
         })
         .build();


### PR DESCRIPTION
Changed `exec` and `execcc` to allow usage of flag names if they've been added. 
**Example:**
`tag1` with `b!t flag add tag1 -f flag`:
```csharp
{flagset;f}
```
`tag2`
```csharp
{exec;tag1;{args}}
```
`b!t tag2 --flag` returns `true`
Current behaviour is seen in the screenshot below
![image](https://user-images.githubusercontent.com/15198000/117856172-967e7400-b28b-11eb-8efa-b209c386c218.png)

I also added a comment to a piece of code that can be removed, as mentioned in the comment itself.
**Added:**
- `flags` parameter to the `execTag` method in `{exec}`
- `.flags` value as argument in `{exec}` and `{execcc}` [8f6f179](https://github.com/blargbot/blargbot/commit/8f6f17981dbc168c6283f0122a0280316a0bc4a5)