### PR TITLE
Possible fix for internal errors coming from rolecreate and rolesetperms

### DIFF
--- a/src/tags/rolecreate.js
+++ b/src/tags/rolecreate.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-21 00:22:32
- * @Last Modified by: stupid cat
- * @Last Modified time: 2019-09-26 09:29:09
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-05-20 23:45:03
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -47,7 +47,7 @@ module.exports =
             if (isNaN(options.permissions))
                 return Builder.util.error(subtag, context, 'Permissions not a number');
 
-            if ((options.permissions & permission.allow) != options.permissions)
+            if ((BigInt(options.permissions) & permission.allow) != options.permissions)
                 return Builder.util.error(subtag, context, 'Author missing requested permissions');
 
             try {

--- a/src/tags/rolesetperms.js
+++ b/src/tags/rolesetperms.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-21 00:22:32
- * @Last Modified by: stupid cat
- * @Last Modified time: 2019-09-26 09:27:55
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-05-20 23:52:32
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -35,7 +35,7 @@ module.exports =
                 perms = bu.parseInt(args[1]) || 0;
 
             const allowedPerms = Builder.util.getPerms(context).allow;
-            const mappedPerms = perms & allowedPerms;
+            const mappedPerms = BigInt(perms) & allowedPerms;
 
             if (role != null) {
                 if (role.position >= topRole)


### PR DESCRIPTION
`{rolecreate}` and `{rolesetperms}` seem to be returning `Internal server occurred`  every single time and from my testings it seems to be because of the error `Cannot mix BigInt and other types, use explicit conversions` on https://github.com/blargbot/blargbot/blob/4d9d40a65efbf5986c073abd101d410bdb0645ff/src/tags/rolecreate.js#L50 and https://github.com/blargbot/blargbot/blob/4d9d40a65efbf5986c073abd101d410bdb0645ff/src/tags/rolesetperms.js#L38

Because these are internal errors I can only try to guess what's going wrong on blarg, but I'm fairly certain that this is the reason of the internal server error

**Changed**:
- Convert `options.permissions` to BigInt [4a2b8a7](https://github.com/blargbot/blargbot/commit/4a2b8a76dcbe7d6d4704161cf759ed43da8ae5ac)
- Convert `perms` to BigInt [4f60c85](https://github.com/blargbot/blargbot/commit/4f60c85788e623feb0423e4078673a016654ea69)