### PR TITLE
Fix timezone errors

### DIFF
--- a/src/dcommands/time.js
+++ b/src/dcommands/time.js
@@ -13,20 +13,20 @@ class TimeCommand extends BaseCommand {
 
     async execute(msg, words, text) {
         var message;
-        let location = moment().tz(words[1] || 'sadasdfsa');
-        if (location.zoneAbbr() !== '') {
+        let location = moment.tz.zone(words[1]);
+        if (location) {
             if (words.length == 2) {
-                if (location.zoneAbbr() !== '')
-                    message = `In **${location.zoneAbbr()}**, it is currently **${location.format('LT')}**`;
+                if (location.abbr(moment()) !== '')
+                    message = `In **${location.abbr(moment())}**, it is currently **${moment.tz(words[1])}**`;
                 else {
                     message = 'Invalid parameters! See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones> for timezone codes that I understand.';
                 }
             } else if (words.length > 3) {
-                var location2 = moment().tz(words[2]);
-                if (location.zoneAbbr() !== '' && location2.zoneAbbr() !== '') {
+                var location2 = moment.tz.zone(words[2]);
+                if (location && location2) {
                     var time = moment.tz(words[3], 'hh:mma', words[1]).tz(words[2]).format('LT');
                     if (time != 'Invalid date')
-                        message = `When it's **${moment.tz(words[3], 'hh:mma', words[1]).format('LT')}** in **${location.zoneAbbr()}**, it's **${time}** in **${location2.zoneAbbr()}**.`;
+                        message = `When it's **${moment.tz(words[3], 'hh:mma', words[1]).format('LT')}** in **${location.abbr(moment())}**, it's **${time}** in **${location2.abbr(moment())}**.`;
                     else
                         message = `Please use the format 'hh:mma' in your time.`;
                 } else
@@ -36,7 +36,7 @@ class TimeCommand extends BaseCommand {
             let user = await bu.getUser(msg, words.length > 1 ? words.slice(1).join(' ') : msg.author.id);
             if (user) {
                 let storedUser = await r.table('user').get(user.id);
-                if (storedUser.timezone) {
+                if (storedUser && storedUser.timezone) {
                     message = `It is currently **${moment().tz(storedUser.timezone).format('LT')}** for **${bu.getFullName(user)}**.`;
                 } else message = `${bu.getFullName(user)} has not set their timezone in the \`timezone\` command yet.`;
             } else {

--- a/src/dcommands/timezone.js
+++ b/src/dcommands/timezone.js
@@ -15,11 +15,11 @@ class TimezoneCommand extends BaseCommand {
         let message;
         if (words.length > 1) {
             let code = words.slice(1).join(' ').toUpperCase();
-            let tz = moment().tz(code);
-            if (tz.zoneAbbr() === '') {
+            let tz = moment.tz.zone(code);
+            if (!tz) {
                 message = 'Invalid parameters! See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones> for timezone codes that I understand.';
             } else {
-                message = `Ok, your timezone code is now set to \`${code}\`, which is equivalent to ${tz.format('z (Z)')}.`;
+                message = `Ok, your timezone code is now set to \`${code}\`, which is equivalent to ${moment.tz(code).format('z (Z)')}.`;
                 await r.table('user').get(msg.author.id).update({ timezone: code });
             }
         } else {

--- a/src/tags/usertimezone.js
+++ b/src/tags/usertimezone.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 19:06:26
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-05-16 10:18:06
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-06-11 10:17:56
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -31,7 +31,7 @@ module.exports =
 
             if (user != null) {
                 let storedUser = await r.table('user').get(user.id);
-                return storedUser.timezone || 'UTC';
+                return (storedUser && storedUser.timezone) || 'UTC';
             }
 
             if (quiet)


### PR DESCRIPTION
**Fixed:**
- `Error: Moment Timezone has no data for ...` in `dcommands/time.js` and `dcommands/timezone.js`
- `Cannot read property 'timezone' of null`

The last fix is purely to prevent the internal error from happening. `bu.processUser` could be used to insert the user into the database, and *then* return `UTC`, but that doesn't really seem necessary.