### PR TITLE
Allow users to delete json keys with jsonset

### DIFF
--- a/src/tags/jsonset.js
+++ b/src/tags/jsonset.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:49:14
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-09-06 14:19:25
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-06-13 22:49:51
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -12,16 +12,17 @@ const Builder = require('../structures/TagBuilder');
 module.exports =
     Builder.ArrayTag('jsonset')
         .withAlias('jset')
-        .withArgs(a => [a.require('input'), a.require('path'), a.require('value'), a.optional('create')])
+        .withArgs(a => [a.require('input'), a.require('path'), a.optional('value'), a.optional('create')])
         .withDesc('Using the `input` as a base, navigates the provided dot-notated `path` and assigns the `value`.' +
-        '`input` can be a JSON object, array, or string. If a string is provided, a variable with the same name will be used.' +
+        '`input` can be a JSON object, array, or string. If a string is provided, a variable with the same name will be used. ' +
+        'If `value` is not provided, this will delete the key at `path`. ' +
         'If `create` is specified, will create/convert any missing keys.')
         .withExample(
         '{jsonset;;path.to.key;value;create}',
         '{"path":{"to":{"key":"value"}}}'
         )
-        .whenArgs('0-2', Builder.errors.notEnoughArguments)
-        .whenArgs('3-4', async function (subtag, context, args) {
+        .whenArgs('0-1', Builder.errors.notEnoughArguments)
+        .whenArgs('2-4', async function (subtag, context, args) {
             let create = args[3] !== undefined;
 
             let obj = args[0], path = args[1], value = args[2];


### PR DESCRIPTION
**Changed**: 
- `{jsonset}` now allows usage with only 2 arguments like `{jset;~json;key}`, which sets `key` to `undefined` and thus removes it from the JSON object