### PR TITLE
Fixes errors in {lock}

### DIFF
--- a/src/tags/lock.js
+++ b/src/tags/lock.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:49:31
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-06-26 14:53:13
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-06-15 13:11:46
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -57,7 +57,7 @@ module.exports =
             let scope = bu.tagVariableScopes.find(s => key.startsWith(s.prefix));
             if (scope == null) throw new Error('Missing default variable scope!');
 
-            let lock = scope.getLock(key.substring(scope.prefix.length));
+            let lock = scope.getLock(context, key.substring(scope.prefix.length));
             let lockFunc = lock[mode + 'Lock'];
 
             let lockOverride = context.override('lock', (subtag, context) => Builder.util.error(subtag, context, 'Lock cannot be nested'));

--- a/src/utils/tag.js
+++ b/src/utils/tag.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 19:22:38
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-09-19 09:11:13
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-06-15 13:15:09
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -177,7 +177,7 @@ bu.tagVariableScopes = [
         getter: async (context, name) =>
             await bu.getVariable(context.guild.id, name,
                 context.isCC && !context.tagVars ? bu.TagVariableType.GUILD : bu.TagVariableType.TAGGUILD),
-        getLock: (context, key) => bu.getLock(...['SERVER', context.isCC ? 'CC' : 'Tag', key])
+        getLock: (context, key) => bu.getLock(...['SERVER', context.guild.id, context.isCC ? 'CC' : 'Tag', key])
     },
     {
         name: 'Author',
@@ -232,7 +232,7 @@ bu.tagVariableScopes = [
                 return await bu.getVariable(context.tagName, name, bu.TagVariableType.GUILDLOCAL, context.guild.id);
             return await bu.getVariable(context.tagName, name, bu.TagVariableType.LOCAL);
         },
-        getLock: (context, key) => bu.getLock(...['LOCAL', context.isCC ? 'CC' : 'TAG', context.tagName])
+        getLock: (context, key) => bu.getLock(...['LOCAL', context.guild.id, context.isCC ? 'CC' : 'TAG', context.tagName])
     }
 ];
 


### PR DESCRIPTION
**Fixed**:
- `Internal server error: TypeError Cannot read property 'id' of undefined` in `getLock` of the author scope ([sentry](https://sentry.blargbot.xyz/organizations/blargbot/issues/269/?query=lock&statsPeriod=14d))
- Server scope not being server-specific.
- Local scope not being server-specific. 

Fixes [#563](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwDg5WovcwMA9NIL/recTshvjPnTbuiL8o?blocks=hide) on airtable