### PR TITLE
Fixed Internal server error in {apply}

### DIFF
--- a/src/tags/apply.js
+++ b/src/tags/apply.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:25:58
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-09-18 14:01:30
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-06-15 19:23:19
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -30,7 +30,8 @@ module.exports =
             let tagArgs = Builder.util.flattenArgArrays(args.slice(1));
             st._protected.children = [new BBTag(args[0])];
 
-            for (const arg of tagArgs) {
+            for (let arg of tagArgs) {
+                arg = typeof arg === 'object' ? JSON.stringify(arg) : arg.toString();
                 let a = new BBTag(arg);
                 a._protected.start = 0;
                 a._protected.end = arg.length;


### PR DESCRIPTION
Because `Builder.util.flattenArgArrays` can return an array with elements that are not just strings, the check inside `bbtag/Tag.js`: https://github.com/blargbot/blargbot/blob/65970bf6ad8d7be41f9cf3cc516f029dbe752c6c/src/structures/bbtag/Tag.js#L57-L62
sets `source` to `undefined`, which results in `Cannot read property 'slice' of undefined` ([sentry](https://sentry.blargbot.xyz/organizations/blargbot/issues/276/?query=is%3Aunresolved)).
Fixes airtable reports: [#340](https://airtable.com/tblyFuWE6fEAbaOfo/viwjCMIsqe4FYzPlu/rec6UGuhAnV9bLLD8?blocks=hide) and [#226](https://airtable.com/tblyFuWE6fEAbaOfo/viwjCMIsqe4FYzPlu/rec0jD8AFb6znqiem?blocks=hide)
**Changed:**
- Stringify every element in `tagArgs`.