### PR TITLE
Added suppresslookup for channel subtags

### DIFF
--- a/src/tags/channelcategory.js
+++ b/src/tags/channelcategory.js
@@ -2,7 +2,7 @@
  * @Author: zoomah
  * @Date: 2018-07-10 7:08:15
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-06-13 14:59:41
+ * @Last Modified time: 2021-06-19 10:25:36
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -21,7 +21,7 @@ module.exports =
         .whenArgs(0, async (_, context) => (context.channel.parentID || ''))
         .whenArgs('1-2', async (subtag, context, args) => {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1];
-            let channel = await Builder.util.parseChannel(context, args[0], { quiet });
+            let channel = await Builder.util.parseChannel(context, args[0], { quiet, suppress: context.scope.suppressLookup });
 
             if (!channel)
                 return quiet ? '' : Builder.errors.noChannelFound(subtag, context);

--- a/src/tags/channeldelete.js
+++ b/src/tags/channeldelete.js
@@ -18,7 +18,7 @@ module.exports =
     )
     .whenArgs(0, Builder.errors.notEnoughArguments)
     .whenArgs('1', async function (subtag, context, args) {
-      let channel = await Builder.util.parseChannel(context, args[0]);
+      let channel = await Builder.util.parseChannel(context, args[0], { suppress: context.scope.suppressLookup });
 
       if (!channel)
         return Builder.errors.noChannelFound(subtag, context);

--- a/src/tags/channeledit.js
+++ b/src/tags/channeledit.js
@@ -28,7 +28,7 @@ module.exports =
     )
     .whenArgs(0, Builder.errors.notEnoughArguments)
     .whenArgs('1-5', async function (subtag, context, args) {
-      let channel = await Builder.util.parseChannel(context, args[0]);
+      let channel = await Builder.util.parseChannel(context, args[0], { suppress: context.scope.suppressLookup });
 
       if (!channel)
         return Builder.errors.noChannelFound(subtag, context);

--- a/src/tags/channelid.js
+++ b/src/tags/channelid.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 18:30:08
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-06-13 15:00:32
+ * @Last Modified time: 2021-06-19 17:53:19
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -22,7 +22,7 @@ module.exports =
         .whenArgs(0, async (_, context) => context.channel.id)
         .whenArgs('1-2', async (subtag, context, args) => {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1];
-            let channel = await Builder.util.parseChannel(context, args[0], {quiet});
+            let channel = await Builder.util.parseChannel(context, args[0], {quiet, suppress: context.scope.suppressLookup });
             if (!channel)
                 return quiet ? '' : Builder.errors.noChannelFound(subtag, context);
 

--- a/src/tags/channeliscategory.js
+++ b/src/tags/channeliscategory.js
@@ -21,7 +21,7 @@ module.exports =
         .whenArgs(0, (_, context) => context.channel.type == 4)
         .whenArgs('1-2', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1];
-            let channel = await Builder.util.parseChannel(context, args[0], { quiet });
+            let channel = await Builder.util.parseChannel(context, args[0], { quiet, suppress: context.scope.suppressLookup });
 
             if (!channel)
                 return quiet ? false : Builder.errors.noChannelFound(subtag, context);

--- a/src/tags/channelisnsfw.js
+++ b/src/tags/channelisnsfw.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 18:50:20
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-06-13 15:07:28
+ * @Last Modified time: 2021-06-19 17:49:41
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -21,7 +21,7 @@ module.exports =
         .whenArgs(0, (_, context) => context.channel.nsfw)
         .whenArgs('1-2', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1];
-            let channel = await Builder.util.parseChannel(context, args[0], { quiet });
+            let channel = await Builder.util.parseChannel(context, args[0], { quiet, suppress: context.scope.suppressLookup });
 
             if (!channel)
                 return quiet ? false : Builder.errors.noChannelFound(subtag, context);

--- a/src/tags/channelistext.js
+++ b/src/tags/channelistext.js
@@ -2,7 +2,7 @@
  * @Author: zoomah
  * @Date: 2018-07-10 7:08:15
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-06-13 15:01:04
+ * @Last Modified time: 2021-06-19 17:49:47
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -21,7 +21,7 @@ module.exports =
         .whenArgs(0, (_, context) => context.channel.type == 0)
         .whenArgs('1-2', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1];
-            let channel = await Builder.util.parseChannel(context, args[0], { quiet });
+            let channel = await Builder.util.parseChannel(context, args[0], { quiet, suppress: context.scope.suppressLookup });
 
             if (!channel)
                 return quiet ? false : Builder.errors.noChannelFound(subtag, context);

--- a/src/tags/channelisvoice.js
+++ b/src/tags/channelisvoice.js
@@ -2,7 +2,7 @@
  * @Author: zoomah
  * @Date: 2018-07-10 7:08:15
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-06-13 15:01:05
+ * @Last Modified time: 2021-06-19 17:49:53
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -21,7 +21,7 @@ module.exports =
         .whenArgs(0, (_, context) => context.channel.type == 2)
         .whenArgs('1-2', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1];
-            let channel = await Builder.util.parseChannel(context, args[0], { quiet });
+            let channel = await Builder.util.parseChannel(context, args[0], { quiet, suppress: context.scope.suppressLookup });
 
             if (!channel)
                 return quiet ? false : Builder.errors.noChannelFound(subtag, context);

--- a/src/tags/channelname.js
+++ b/src/tags/channelname.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 18:30:19
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-06-13 15:01:14
+ * @Last Modified time: 2021-06-19 17:50:00
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -21,7 +21,7 @@ module.exports =
         .whenArgs(0, async (_, context) => context.channel.name)
         .whenArgs('1-2', async (subtag, context, args) => {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1];
-            let channel = await Builder.util.parseChannel(context, args[0], { quiet });
+            let channel = await Builder.util.parseChannel(context, args[0], { quiet, suppress: context.scope.suppressLookup });
             if (!channel)
                 return quiet ? '' : Builder.errors.noChannelFound(subtag, context);
 

--- a/src/tags/channelpos.js
+++ b/src/tags/channelpos.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 18:30:28
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-06-13 15:01:19
+ * @Last Modified time: 2021-06-19 17:50:06
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -22,7 +22,7 @@ module.exports =
         .whenArgs(0, async (_, context) => context.channel.position)
         .whenArgs('1-2', async (subtag, context, args) => {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1];
-            let channel = await Builder.util.parseChannel(context, args[0], { quiet });
+            let channel = await Builder.util.parseChannel(context, args[0], { quiet, suppress: context.scope.suppressLookup });
             if (!channel)
                 return quiet ? '' : Builder.errors.noChannelFound(subtag, context);
 

--- a/src/tags/channelsetperms.js
+++ b/src/tags/channelsetperms.js
@@ -26,7 +26,7 @@ module.exports =
     )
     .whenArgs(0, Builder.errors.notEnoughArguments)
     .whenArgs('1-5', async function (subtag, context, args) {
-      let channel = await Builder.util.parseChannel(context, args[0]);
+      let channel = await Builder.util.parseChannel(context, args[0], { suppress: context.scope.suppressLookup });
 
       if (!channel)
         return Builder.errors.noChannelFound(subtag, context);

--- a/src/tags/channelsetpos.js
+++ b/src/tags/channelsetpos.js
@@ -14,7 +14,7 @@ module.exports =
     )
     .whenArgs('0-1', Builder.errors.notEnoughArguments)
     .whenArgs(2, async function (subtag, context, args) {
-      let channel = await Builder.util.parseChannel(context, args[0]);
+      let channel = await Builder.util.parseChannel(context, args[0], { suppress: context.scope.suppressLookup });
 
       if (!channel)
         return Builder.errors.noChannelFound(subtag, context);


### PR DESCRIPTION
Allow users to suppress the "No channels found" output from the lookup system, because of [this discussion](https://discord.com/channels/194232473931087872/238131984017260546/855639759347122186)

**Added:**
- Pass on `context.scope.suppressLookup` to channel lookups