### PR TITLE
Bumped twemoji to 13.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "strip-ansi": "^4.0.0",
         "svg2png": "^4.1.1",
         "table": "^4.0.3",
-        "twemoji": "^11.0.1",
+        "twemoji": "^13.1.0",
         "unorm": "^1.4.1",
         "usage": "^0.7.1",
         "vue-markdown": "^2.2.4",


### PR DESCRIPTION
Seems like it would be a good idea to update this package to `13.1.0`, a lot of emojis have been added o/
[list of releases after 11.0.1](https://github.com/twitter/twemoji/releases?after=v11.0.1)