### PR TITLE
Set member to context.member where possible

### DIFF
--- a/src/tags/isuserboosting.js
+++ b/src/tags/isuserboosting.js
@@ -9,8 +9,10 @@ module.exports =
         .withExample(
             '{if;{isuserboosting;stupid cat};stupid cat is boosting!; no boosting here :(}',
             'stupid cat is boosting!'
-        )
-        .whenArgs('0-2', async function (subtag, context, args) {
+        ).whenArgs(0, (_, context) => {
+            return !!context.member.premiumSince;
+        })
+        .whenArgs('1-2', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1],
                 user = context.user;
 
@@ -19,7 +21,7 @@ module.exports =
                     quiet, suppress: context.scope.suppressLookup,
                     label: `${context.isCC ? 'custom command' : 'tag'} \`${context.tagName || 'unknown'}\``
                 });
-            
+
             if (user != null) {
                 let member = context.guild.members.get(user.id);
                 if (member != null) return !!member.premiumSince;

--- a/src/tags/roles.js
+++ b/src/tags/roles.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-21 00:22:32
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-05-16 10:20:02
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-06-21 11:55:37
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -33,8 +33,16 @@ module.exports =
 
             if (user != null) {
                 let guildRoles = context.guild.roles.map(r => r).reduce((o, r) => (o[r.id] = r, o), {});
-                let roles = context.guild.members.get(user.id).roles.map(r => guildRoles[r]);
-                return JSON.stringify(roles.sort((a, b) => b.position - a.position).map(r => r.id));
+                let member;
+                if (user.id === context.member.id) {
+                    member = context.member;
+                } else {
+                    member = context.guild.members.get(user.id);
+                }
+                if (member) {
+                    let roles = context.guild.members.get(user.id).roles.map(r => guildRoles[r]);
+                    return JSON.stringify(roles.sort((a, b) => b.position - a.position).map(r => r.id));
+                }
             }
 
             if (quiet)

--- a/src/tags/userboostdate.js
+++ b/src/tags/userboostdate.js
@@ -13,8 +13,11 @@ module.exports =
         .withExample(
             'Your account started boosting this guild on {userboostdate;YYYY/MM/DD HH:mm:ss}',
             'Your account started boosting this guild on 2020/02/27 00:00:00'
-        )
-        .whenArgs('0-3', async function (subtag, context, args) {
+        ).whenArgs('0-1', (subtag, context, args) => {
+            if (!context.member.premiumSince) return Builder.errors.customError(subtag, context, 'User not boosting');
+            return moment(context.member.premiumSince).utcOffset(0).format(args[0] || '');
+        })
+        .whenArgs('2-3', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[2],
                 user = context.user;
 
@@ -23,12 +26,12 @@ module.exports =
                     quiet, suppress: context.scope.suppressLookup,
                     label: `${context.isCC ? 'custom command' : 'tag'} \`${context.tagName || 'unknown'}\``
                 });
-            
+
             if (user != null) {
                 let member = context.guild.members.get(user.id);
                 if (member != null) {
                   //Not sure if this needs the error to be in TagBuilder.errors as it's just used once.
-                  if(!member.premiumSince) return Builder.errors.customError(subtag, context, 'User not boosting');
+                  if (!member.premiumSince) return Builder.errors.customError(subtag, context, 'User not boosting');
                   return moment(member.premiumSince).utcOffset(0).format(args[0] || '');
                 }
                 return Builder.errors.userNotInGuild(subtag, context);

--- a/src/tags/userjoinedat.js
+++ b/src/tags/userjoinedat.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 19:20:29
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-05-16 10:17:44
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-06-21 11:43:53
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -21,8 +21,10 @@ module.exports =
         .withExample(
             'Your account joined this guild on {usercreatedat;YYYY/MM/DD HH:mm:ss}',
             'Your account joined this guild on 2016/01/01 01:00:00.'
-        )
-        .whenArgs('0-3', async function (subtag, context, args) {
+        ).whenArgs('0-1', (_, context, args) => {
+            return moment(context.member.joinedAt).utcOffset(0).format(args[0] || '');
+        })
+        .whenArgs('2-3', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[2],
                 user = context.user;
 

--- a/src/tags/usernick.js
+++ b/src/tags/usernick.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 19:20:48
- * @Last Modified by: stupid cat
- * @Last Modified time: 2019-02-26 13:42:36
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-06-21 11:49:51
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -19,7 +19,9 @@ module.exports =
             'Your nick is {usernick}!',
             'Your nick is Cool Dude 1337!'
         )
-        .whenArgs('0-2', async function (subtag, context, args) {
+        .whenArgs(0, (_, context) => (context.member.nick || context.user.username).replace(/@/g, '@\u200b'))
+
+        .whenArgs('1-2', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1],
                 user = context.user;
 

--- a/src/tags/userroles.js
+++ b/src/tags/userroles.js
@@ -8,8 +8,8 @@ module.exports =
         .withExample(
             'Your roles are {userroles}!',
             'Your roles are ["1111111111111111","2222222222222222"]!'
-        )
-        .whenArgs('0-2', async function (subtag, context, args) {
+        ).whenArgs(0, (_, context) => context.member.roles)
+        .whenArgs('1-2', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1],
                 user = context.user;
 

--- a/src/tags/userstatus.js
+++ b/src/tags/userstatus.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 19:20:55
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-05-16 10:17:59
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-06-21 11:40:21
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -18,8 +18,8 @@ module.exports =
         .withExample(
             'You are currently {userstatus}',
             'You are currently online'
-        )
-        .whenArgs('0-2', async function (subtag, context, args) {
+        ).whenArgs(0, (_, context) => context.member.status)
+        .whenArgs('1-2', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1],
                 user = context.user;
 


### PR DESCRIPTION
Added separate `0` argument handler for subtags where it defaults to the user executing the command/tag. This doesn't change anything in situations where the member is still in the guild, but for `farewell` it does.
Example where a user nicked `Custom nickname` leaves (where blargnot has the changes in this PR):
![afbeelding](https://user-images.githubusercontent.com/15198000/122745105-f30c8000-d288-11eb-8d9e-91bd03555784.png)

Stems from discord issue where `{usernick}` didn't work in farewells:
![afbeelding](https://user-images.githubusercontent.com/15198000/122745374-3961df00-d289-11eb-917b-9cdc1ada6ba6.png)


**Changed**:
- subtags with member defaults to use `context.member` and not the `context.guild.members` cache

