### PR TITLE
Increased embed description limit to 4096

### DIFF
--- a/src/tags/embedbuild.js
+++ b/src/tags/embedbuild.js
@@ -21,7 +21,7 @@ const fields = [
     },
     {
         key: 'description',
-        error: (e, v) => v.length > 2048
+        error: (e, v) => v.length > 4096
             ? 'Description too long'
             : false,
         parse: v => v,


### PR DESCRIPTION
https://discord.com/developers/docs/resources/channel#embed-limits states the description size limit is now `4096` instead of `2048`. It seems like the description length is checking in `{embedbuild}` only.