### PR TITLE
Ability to toggle pings with mention subtags added

### DIFF
--- a/src/tags/rolemention.js
+++ b/src/tags/rolemention.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-21 00:22:32
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-05-16 10:04:27
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-07-03 19:13:43
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -11,23 +11,28 @@ const Builder = require('../structures/TagBuilder');
 
 module.exports =
     Builder.APITag('rolemention')
-        .withArgs(a => [a.require('role'), a.optional('quiet')])
+        .withArgs(a => [a.require('role'), a.optional('quiet'), a.optional('noPing')])
         .withDesc('Returns a mention of `role`. ' +
-            'If `quiet` is specified, if `role` can\'t be found it will simply return nothing.')
+            'If `quiet` is specified (can be any value), if `role` can\'t be found it will simply return nothing.' +
+            ' If `noPing` is `true` (must be a boolean), role won\'t be pinged but the mention will still be displayed, if it is `false` the mention will ping.')
         .withExample(
             'The admin role ID is: {roleid;admin}.',
             'The admin role ID is: 123456789123456.'
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
-        .whenArgs('1-2', async function (subtag, context, args) {
+        .whenArgs('1-3', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1],
                 role = await context.getRole(args[0], {
                     quiet, suppress: context.scope.suppressLookup,
                     label: `${context.isCC ? 'custom command' : 'tag'} \`${context.tagName || 'unknown'}\``
                 });
+            const noPing = bu.parseBoolean(args[2]);
+            if (args[2] && typeof noPing !== 'boolean') {
+                return Builder.errors.notABoolean(subtag, context);
+            }
 
             if (role != null) {
-                if (!context.state.allowedMentions.roles.includes(role.id)) {
+                if (!noPing && !context.state.allowedMentions.roles.includes(role.id)) {
                     context.state.allowedMentions.roles.push(role.id);
                 }
                 return role.mention;

--- a/src/tags/usermention.js
+++ b/src/tags/usermention.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 19:20:35
- * @Last Modified by: stupid cat
- * @Last Modified time: 2018-05-16 10:01:47
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-07-03 19:13:01
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -11,17 +11,21 @@ const Builder = require('../structures/TagBuilder');
 
 module.exports =
     Builder.APITag('usermention')
-        .withArgs(a => [a.optional('user'), a.optional('quiet')])
+        .withArgs(a => [a.optional('user'), a.optional('quiet'), a.optional('noPing')])
         .withDesc('Mentions `user`. `user` defaults to the user who executed the containing tag. ' +
-            'If `quiet` is specified, if `user` can\'t be found it will simply return nothing.')
+            'If `quiet` is specified (can be any value), if `user` can\'t be found it will simply return nothing. ' +
+            'If `noPing` is `true` (must be a boolean), user won\'t be pinged but the mention will still be displayed, if it is `false` the mention will ping.')
         .withExample(
             'Hello, {usermention}!',
             'Hello, @user!'
         )
-        .whenArgs('0-2', async function (subtag, context, args) {
+        .whenArgs('0-3', async function (subtag, context, args) {
             let quiet = bu.isBoolean(context.scope.quiet) ? context.scope.quiet : !!args[1],
                 user = context.user;
-
+            const noPing = bu.parseBoolean(args[2]);
+            if (args[2] && typeof noPing !== 'boolean') {
+                return Builder.errors.notABoolean(subtag, context);
+            }
             if (args[0])
                 user = await context.getUser(args[0], {
                     quiet, suppress: context.scope.suppressLookup,
@@ -29,7 +33,7 @@ module.exports =
                 });
 
             if (user != null) {
-                if (!context.state.allowedMentions.users.includes(user.id)) {
+                if (!noPing && !context.state.allowedMentions.users.includes(user.id)) {
                     context.state.allowedMentions.users.push(user.id);
                 }
                 return user.mention;


### PR DESCRIPTION
Following from [support discussion](https://discord.com/channels/194232473931087872/238131984017260546/860912164910923796)
![image](https://user-images.githubusercontent.com/15198000/124362121-6328e780-dc33-11eb-8797-4eebe86510f0.png)

As seen in this PR, the allowed argument for `[noPing]` must be a `boolean`, unlike for example `[quiet]`. Eventually imo all parameters with 'toggle behaviour' should accept booleans only (or maybe a mix of boolean/truthy)