### PR TITLE
Added more transparent information regarding timeouts

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 18:22:24
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-08-02 18:34:43
+ * @Last Modified time: 2021-08-03 12:08:32
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -186,7 +186,7 @@ async function exceededRatelimit(msg) {
 
     if (commandUsage[msg.author.id].length >= maxExecutions) {
         timedOut[msg.author.id] = Date.now() + timeoutDuration;
-        await bu.send(msg, 'Sorry, you\'ve been running too many commands. To prevent abuse, I\'m going to have to time you out for `' + timeoutDuration / 1000 + 's`.\n\nContinuing to spam commands will lengthen your timeout by `5s`! To prevent being timed out, please avoid using `' + maxExecutions + '` commands within `' + maxTime / 1000 + 's`');
+        await bu.send(msg, 'Sorry, you\'ve been running too many commands. To prevent abuse, I\'m going to have to time you out for `' + timeoutDuration / 1000 + 's`.\n\nContinuing to spam commands will lengthen your timeout by `5s`!');
         return true;
     }
 

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:22:24
- * @Last Modified by: stupid cat
- * @Last Modified time: 2019-07-29 17:55:23
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-08-02 18:34:43
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -171,7 +171,7 @@ async function exceededRatelimit(msg) {
     }
     if (timedOut[msg.author.id]) {
         if (Date.now() < timedOut[msg.author.id]) {
-            timedOut[msg.author.id] += 5000;
+            timedOut[msg.author.id] += 5000; //TODO Use configured penalty value
             return true;
         } else {
             delete timedOut[msg.author.id];
@@ -186,7 +186,7 @@ async function exceededRatelimit(msg) {
 
     if (commandUsage[msg.author.id].length >= maxExecutions) {
         timedOut[msg.author.id] = Date.now() + timeoutDuration;
-        await bu.send(msg, 'Sorry, you\'ve been running too many commands. To prevent abuse, I\'m going to have to time you out.\n\nContinuing to spam commands will lengthen your timeout!');
+        await bu.send(msg, 'Sorry, you\'ve been running too many commands. To prevent abuse, I\'m going to have to time you out for `' + timeoutDuration / 1000 + 's`.\n\nContinuing to spam commands will lengthen your timeout by `5s`! To prevent being timed out, please avoid using `' + maxExecutions + '` commands within `' + maxTime / 1000 + 's`');
         return true;
     }
 


### PR DESCRIPTION
Seeing as the command timeout isn't really documented anywhere, I added some more info to the 'timeout message'.

**NOTE**: I also noticed that the `penalty` variable is unused (kept it that way), but it might be good to keep this in mind in case the penalty gets modified in the future.