### PR TITLE
Split the custom commands category in sections

### DIFF
--- a/src/dcommands/help.js
+++ b/src/dcommands/help.js
@@ -132,10 +132,34 @@ class HelpCommand extends BaseCommand {
                                 helpCommandList.push(key);
                         }
                         helpCommandList.sort();
-                        embed.fields.push({
+                        const sections = [];
+                        var section = {
                             name: 'Custom Commands',
-                            value: '```\n' + helpCommandList.join(', ') + '\n```'
-                        });
+                            value: '```\n'
+                        };
+                        for (var i = 0; i < helpCommandList.length; i++) {
+                            if (i === 0) {
+                                section.value += helpCommandList[i];
+                                continue;
+                            }
+
+                            if ((section.value + ', ' + helpCommandList[i]).length < 1020) {
+                                section.value += ', ' + helpCommandList[i];
+                            } else {
+                                section.value += '\n```';
+                                sections.push(section);
+                                section = {
+                                    name: '\u200b',
+                                    value: '```\n' + helpCommandList[i]
+                                };
+                            }
+
+                            if (i === helpCommandList.length - 1) {
+                                section.value += '\n```';
+                                sections.push(section);
+                            }
+                        }
+                        embed.fields.push(...sections);
                     }
                 }
 

--- a/src/dcommands/help.js
+++ b/src/dcommands/help.js
@@ -153,12 +153,9 @@ class HelpCommand extends BaseCommand {
                                     value: '```\n' + helpCommandList[i]
                                 };
                             }
-
-                            if (i === helpCommandList.length - 1) {
-                                section.value += '\n```';
-                                sections.push(section);
-                            }
                         }
+                        section.value += '\n```';
+                        sections.push(section);
                         embed.fields.push(...sections);
                     }
                 }


### PR DESCRIPTION
This doesn't entirely fix the issue when the `b!help` embed (or other embeds for that matter) is exceeds the limits, but it should give some space for more custom commands.

Ultimately something similar to `blargbot.xyz/output` should be created for embeds too, while keeping the visual aspect somewhat intact

**Changed**:
- `b!help`'s embed will now have more fields for custom commands, when they exceed the `1024` character limit.

**Discord discussion**
![image](https://user-images.githubusercontent.com/15198000/128614675-321b9130-9105-4e07-a431-cb6fcd8dd755.png)
