### PR TITLE
Implementing discord Timestamps

### DIFF
--- a/src/dcommands/ban.js
+++ b/src/dcommands/ban.js
@@ -75,7 +75,8 @@ class BanCommand extends BaseCommand {
             const fullReason = (tag ? '' : `[ ${bu.getFullName(msg.author)} ]`) + (reason ? ' ' + reason : '');
             await bot.banGuildMember(msg.channel.guild.id, user.id, deleteDays, encodeURIComponent(fullReason));
             let suffix = '';
-            let unban_at = r.epochTime(moment().add(duration).unix());
+            let unban_at = moment().add(duration).unix();
+
             if (duration) {
                 await bu.events.insert({
                     type: 'unban',

--- a/src/dcommands/ban.js
+++ b/src/dcommands/ban.js
@@ -75,6 +75,7 @@ class BanCommand extends BaseCommand {
             const fullReason = (tag ? '' : `[ ${bu.getFullName(msg.author)} ]`) + (reason ? ' ' + reason : '');
             await bot.banGuildMember(msg.channel.guild.id, user.id, deleteDays, encodeURIComponent(fullReason));
             let suffix = '';
+            let unban_at = r.epochTime(moment().add(duration).unix());
             if (duration) {
                 await bu.events.insert({
                     type: 'unban',
@@ -83,10 +84,10 @@ class BanCommand extends BaseCommand {
                     content: `${user.username}#${user.discriminator}`,
                     guild: msg.guild.id,
                     duration: duration.toJSON(),
-                    endtime: r.epochTime(moment().add(duration).unix()),
+                    endtime: unban_at,
                     starttime: r.epochTime(moment().unix())
                 });
-                return [`:ok_hand: The user will be unbanned ${duration.humanize(true)}.`, duration.asMilliseconds()];
+                return [`:ok_hand: The user will be unbanned at <t:${unban_at}:F> (<t:${unban_at}:R>)`, duration.asMilliseconds()];
             } else {
                 return [`:ok_hand:`, true];
             }

--- a/src/dcommands/ban.js
+++ b/src/dcommands/ban.js
@@ -85,7 +85,8 @@ class BanCommand extends BaseCommand {
                     content: `${user.username}#${user.discriminator}`,
                     guild: msg.guild.id,
                     duration: duration.toJSON(),
-                    endtime: unban_at,
+                    endtime: r.epochTime(unban_at),
+
                     starttime: r.epochTime(moment().unix())
                 });
                 return [`:ok_hand: The user will be unbanned at <t:${unban_at}:F> (<t:${unban_at}:R>)`, duration.asMilliseconds()];

--- a/src/dcommands/mute.js
+++ b/src/dcommands/mute.js
@@ -112,7 +112,8 @@ class MuteCommand extends BaseCommand {
                             let suffix = '';
                             if (input.t) {
                                 let duration = bu.parseDuration(input.t.join(' '));
-                                let unmute_at = r.epochTime(moment().add(duration).unix());
+                                let unmute_at = moment().add(duration).unix();
+
                                 if (duration.asMilliseconds() > 0) {
                                     await bu.events.insert({
                                         type: 'unmute',

--- a/src/dcommands/mute.js
+++ b/src/dcommands/mute.js
@@ -123,7 +123,8 @@ class MuteCommand extends BaseCommand {
                                         guild: msg.guild.id,
                                         duration: duration.toJSON(),
                                         role: mutedrole,
-                                        endtime: unmute_at,
+                                        endtime: r.epochTime(unmute_at),
+
                                         starttime: r.epochTime(moment().unix())
                                     });
                                     suffix = `The user will be unmuted <t:${unmute_at}:F> (<t:${unmute_at}:R>).`;

--- a/src/dcommands/mute.js
+++ b/src/dcommands/mute.js
@@ -112,6 +112,7 @@ class MuteCommand extends BaseCommand {
                             let suffix = '';
                             if (input.t) {
                                 let duration = bu.parseDuration(input.t.join(' '));
+                                let unmute_at = r.epochTime(moment().add(duration).unix());
                                 if (duration.asMilliseconds() > 0) {
                                     await bu.events.insert({
                                         type: 'unmute',
@@ -121,10 +122,10 @@ class MuteCommand extends BaseCommand {
                                         guild: msg.guild.id,
                                         duration: duration.toJSON(),
                                         role: mutedrole,
-                                        endtime: r.epochTime(moment().add(duration).unix()),
+                                        endtime: unmute_at,
                                         starttime: r.epochTime(moment().unix())
                                     });
-                                    suffix = `The user will be unmuted ${duration.humanize(true)}.`;
+                                    suffix = `The user will be unmuted <t:${unmute_at}:F> (<t:${unmute_at}:R>).`;
                                 } else {
                                     suffix = `The user was muted, but the duration was either 0 seconds or improperly formatted so they won't automatically be unmuted.`;
                                 }

--- a/src/dcommands/remind.js
+++ b/src/dcommands/remind.js
@@ -51,7 +51,7 @@ Example: ${example}`);
             starttime: r.epochTime(moment().unix()),
             endtime: r.epochTime(moment().add(duration).unix())
         });
-        await bu.send(msg, `:alarm_clock: Ok! I'll remind you ${channel ? 'here' : 'in a DM'} <t:${r.epochTime(moment().add(duration).unix())}:R>! :alarm_clock: `);
+        await bu.send(msg, `:alarm_clock: Ok! I'll remind you ${channel ? 'here' : 'in a DM'} <t:${moment().add(duration).unix()}:R>! :alarm_clock: `);
     }
 
     async event(args) {
@@ -64,7 +64,7 @@ ${args.content}`,
                 }
             });
         } else {
-            bu.sendDM(args.user, `:alarm_clock: Hi! You asked me to remind you about this <t:${args.starttime}:R> :
+            bu.sendDM(args.user, `:alarm_clock: Hi! You asked me to remind you about this <t:${moment(args.starttime).unix()}:R> :
     ${args.content}`);
         }
     };

--- a/src/dcommands/remind.js
+++ b/src/dcommands/remind.js
@@ -51,7 +51,7 @@ Example: ${example}`);
             starttime: r.epochTime(moment().unix()),
             endtime: r.epochTime(moment().add(duration).unix())
         });
-        await bu.send(msg, `:alarm_clock: Ok! I'll remind you ${channel ? 'here' : 'in a DM'} ${duration.humanize(true)}! :alarm_clock: `);
+        await bu.send(msg, `:alarm_clock: Ok! I'll remind you ${channel ? 'here' : 'in a DM'} <t:${r.epochTime(moment().add(duration).unix())}:R>! :alarm_clock: `);
     }
 
     async event(args) {

--- a/src/dcommands/remind.js
+++ b/src/dcommands/remind.js
@@ -55,18 +55,16 @@ Example: ${example}`);
     }
 
     async event(args) {
-        let duration = moment.duration(moment() - moment(args.starttime));
-        duration.subtract(duration * 2);
         if (args.channel) {
             bu.send(args.channel, {
-                content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this ${duration.humanize(true)}:
+                content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this <t:${args.starttime}:> :
 ${args.content}`,
                 allowedMentions: {
                     users: [args.user]
                 }
             });
         } else {
-            bu.sendDM(args.user, `:alarm_clock: Hi! You asked me to remind you about this ${duration.humanize(true)}:
+            bu.sendDM(args.user, `:alarm_clock: Hi! You asked me to remind you about this <t:${args.starttime}:> :
     ${args.content}`);
         }
     };

--- a/src/dcommands/remind.js
+++ b/src/dcommands/remind.js
@@ -56,7 +56,7 @@ Example: ${example}`);
     }
 
     async event(args) {
-        let endUnix = moment().add(duration).unix();
+        let endUnix = moment(args.starttime).unix();
         if (args.channel) {
             bu.send(args.channel, {
                 content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this <t:${endUnix}:R> :

--- a/src/dcommands/remind.js
+++ b/src/dcommands/remind.js
@@ -41,8 +41,8 @@ Example: ${example}`);
         }
 
         let channel;
-        if (input.c) channel = msg.channel.id;
         let endUnix = moment().add(duration).unix();
+        if (input.c) channel = msg.channel.id;
         await bu.events.insert({
             type: 'remind',
             source: channel ? msg.guild.id : msg.author.id,
@@ -56,6 +56,7 @@ Example: ${example}`);
     }
 
     async event(args) {
+        let endUnix = moment().add(duration).unix();
         if (args.channel) {
             bu.send(args.channel, {
                 content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this <t:${endUnix}:R> :
@@ -65,7 +66,7 @@ ${args.content}`,
                 }
             });
         } else {
-            bu.sendDM(args.user, `:alarm_clock: Hi! You asked me to remind you about this <t:${moment(args.starttime).unix()}:R> :
+            bu.sendDM(args.user, `:alarm_clock: Hi! You asked me to remind you about this <t:${endUnix}:R> :
     ${args.content}`);
         }
     };

--- a/src/dcommands/remind.js
+++ b/src/dcommands/remind.js
@@ -42,6 +42,7 @@ Example: ${example}`);
 
         let channel;
         if (input.c) channel = msg.channel.id;
+        let endUnix = moment().add(duration).unix();
         await bu.events.insert({
             type: 'remind',
             source: channel ? msg.guild.id : msg.author.id,
@@ -49,15 +50,15 @@ Example: ${example}`);
             content: input.undefined.join(' '),
             channel: channel,
             starttime: r.epochTime(moment().unix()),
-            endtime: r.epochTime(moment().add(duration).unix())
+            endtime: r.epochTime(endUnix)
         });
-        await bu.send(msg, `:alarm_clock: Ok! I'll remind you ${channel ? 'here' : 'in a DM'} <t:${moment().add(duration).unix()}:R>! :alarm_clock: `);
+        await bu.send(msg, `:alarm_clock: Ok! I'll remind you ${channel ? 'here' : 'in a DM'} <t:${endUnix}:R>! :alarm_clock: `);
     }
 
     async event(args) {
         if (args.channel) {
             bu.send(args.channel, {
-                content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this <t:${moment(args.starttime).unix()}:R> :
+                content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this <t:${endUnix}:R> :
 ${args.content}`,
                 allowedMentions: {
                     users: [args.user]

--- a/src/dcommands/remind.js
+++ b/src/dcommands/remind.js
@@ -57,14 +57,14 @@ Example: ${example}`);
     async event(args) {
         if (args.channel) {
             bu.send(args.channel, {
-                content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this <t:${args.starttime}:> :
+                content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this <t:${args.starttime}:R> :
 ${args.content}`,
                 allowedMentions: {
                     users: [args.user]
                 }
             });
         } else {
-            bu.sendDM(args.user, `:alarm_clock: Hi! You asked me to remind you about this <t:${args.starttime}:> :
+            bu.sendDM(args.user, `:alarm_clock: Hi! You asked me to remind you about this <t:${args.starttime}:R> :
     ${args.content}`);
         }
     };

--- a/src/dcommands/remind.js
+++ b/src/dcommands/remind.js
@@ -57,7 +57,7 @@ Example: ${example}`);
     async event(args) {
         if (args.channel) {
             bu.send(args.channel, {
-                content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this <t:${args.starttime}:R> :
+                content: `:alarm_clock: Hi, <@${args.user}>! You asked me to remind you about this <t:${moment(args.starttime).unix()}:R> :
 ${args.content}`,
                 allowedMentions: {
                     users: [args.user]

--- a/src/dcommands/time.js
+++ b/src/dcommands/time.js
@@ -34,13 +34,11 @@ class TimeCommand extends BaseCommand {
             }
         } else {
             let user = await bu.getUser(msg, words.length > 1 ? words.slice(1).join(' ') : msg.author.id);
-            if (user && !(user.id == msg.author.id)) {
+            if (user) {
                 let storedUser = await r.table('user').get(user.id);
                 if (storedUser && storedUser.timezone) {
                     message = `It is currently **${moment().tz(storedUser.timezone).format('LT')}** for **${bu.getFullName(user)}**.`;
                 } else message = `${bu.getFullName(user)} has not set their timezone in the \`timezone\` command yet.`;
-            } else if (user.id == msg.author.id) {
-                message = `It is currently <t:${moment().unix()}> for you.`;
             } else {
                 message = 'You either provided an invalid user or an invalid timezone code. See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones> for timezone codes that I understand.';
             }

--- a/src/dcommands/time.js
+++ b/src/dcommands/time.js
@@ -39,6 +39,8 @@ class TimeCommand extends BaseCommand {
                 if (storedUser && storedUser.timezone) {
                     message = `It is currently **${moment().tz(storedUser.timezone).format('LT')}** for **${bu.getFullName(user)}**.`;
                 } else message = `${bu.getFullName(user)} has not set their timezone in the \`timezone\` command yet.`;
+            } else if (user.id == msg.author.id) {
+                message = `It is currently <t:${moment().unix()}> for you.`;
             } else {
                 message = 'You either provided an invalid user or an invalid timezone code. See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones> for timezone codes that I understand.';
             }

--- a/src/dcommands/time.js
+++ b/src/dcommands/time.js
@@ -34,7 +34,7 @@ class TimeCommand extends BaseCommand {
             }
         } else {
             let user = await bu.getUser(msg, words.length > 1 ? words.slice(1).join(' ') : msg.author.id);
-            if (user) {
+            if (user && !(user.id == msg.author.id)) {
                 let storedUser = await r.table('user').get(user.id);
                 if (storedUser && storedUser.timezone) {
                     message = `It is currently **${moment().tz(storedUser.timezone).format('LT')}** for **${bu.getFullName(user)}**.`;

--- a/src/dcommands/timer.js
+++ b/src/dcommands/timer.js
@@ -31,10 +31,8 @@ class TimerCommand extends BaseCommand {
     }
 
     async event(args) {
-        let duration = moment.duration(moment() - moment(args.starttime));
-        duration.subtract(duration * 2);
         bu.send(args.channel, {
-            content: `:alarm_clock: *Bzzt!* <@${args.user}>, the timer you set ${duration.humanize(true)} has gone off! *Bzzt!* :alarm_clock:`,
+            content: `:alarm_clock: *Bzzt!* <@${args.user}>, the timer you set <t:${args.starttime}:R> has gone off! *Bzzt!* :alarm_clock:`,
             allowedMentions: {
                 users: [args.user]
             }

--- a/src/dcommands/timer.js
+++ b/src/dcommands/timer.js
@@ -32,8 +32,9 @@ class TimerCommand extends BaseCommand {
     }
 
     async event(args) {
+        let startUnix = moment(args.starttime).unix();
         bu.send(args.channel, {
-            content: `:alarm_clock: *Bzzt!* <@${args.user}>, the timer you set <t:${moment(args.starttime).unix()}:R> has gone off! *Bzzt!* :alarm_clock:`,
+            content: `:alarm_clock: *Bzzt!* <@${args.user}>, the timer you set <t:${startUnix}:R> has gone off! *Bzzt!* :alarm_clock:`,
             allowedMentions: {
                 users: [args.user]
             }

--- a/src/dcommands/timer.js
+++ b/src/dcommands/timer.js
@@ -18,15 +18,16 @@ class TimerCommand extends BaseCommand {
         if (duration.asMilliseconds() == 0) {
             await bu.send(msg, 'Hey, you didn\'t give me a period of time to set the timer to!\nExample: `timer 1 day, two hours`');
         } else {
+            let endUnix = moment().add(duration).unix();
             await bu.events.insert({
                 type: 'timer',
                 source: msg.guild ? msg.guild.id : msg.author.id,
                 user: msg.author.id,
                 channel: msg.channel.id,
                 starttime: r.epochTime(moment().unix()),
-                endtime: r.epochTime(moment().add(duration).unix())
+                endtime: r.epochTime(endUnix)
             });
-            await bu.send(msg, `:alarm_clock: Ok! The timer will go off ${duration.humanize(true)}! :alarm_clock: `);
+            await bu.send(msg, `:alarm_clock: Ok! The timer will go off at <t:${endUnix}> :alarm_clock: `);
         }
     }
 

--- a/src/dcommands/timer.js
+++ b/src/dcommands/timer.js
@@ -32,7 +32,7 @@ class TimerCommand extends BaseCommand {
 
     async event(args) {
         bu.send(args.channel, {
-            content: `:alarm_clock: *Bzzt!* <@${args.user}>, the timer you set <t:${args.starttime}:R> has gone off! *Bzzt!* :alarm_clock:`,
+            content: `:alarm_clock: *Bzzt!* <@${args.user}>, the timer you set <t:${moment(args.starttime).unix()}:R> has gone off! *Bzzt!* :alarm_clock:`,
             allowedMentions: {
                 users: [args.user]
             }

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -49,8 +49,7 @@ bot.on('guildMemberAdd', async function (guild, member) {
         inline: true
     }, {
         name: 'Created',
-        value: moment(member.user.createdAt).tz('Etc/GMT').format('llll') +
-            ` GMT\n(${moment.duration(-1 * (moment() - moment(member.user.createdAt))).humanize(true)})`,
+        value: `<t:${moment(member.user.createdAt).unix()}> (<t:${moment(member.user.createdAt).unix()}:R>)`, // we need to show there account age too right.
         inline: false
     }]);
 });

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -14,6 +14,7 @@ bot.on('guildMemberAdd', async function (guild, member) {
     let val = await bu.guildSettings.get(guild.id, 'greeting');
     let chan = await bu.guildSettings.get(guild.id, 'greetchan');
     let channel;
+    let userCreatedAtUnix = moment(member.user.createdAt).unix();
     if (chan && val) {
         channel = bot.getChannel(chan);
     }
@@ -49,7 +50,7 @@ bot.on('guildMemberAdd', async function (guild, member) {
         inline: true
     }, {
         name: 'Created',
-        value: `<t:${moment(member.user.createdAt).unix()}> (<t:${moment(member.user.createdAt).unix()}:R>)`, // we need to show there account age too right.
+        value: `<t:${userCreatedAtUnix}> (<t:${userCreatedAtUnix}:R>)`, // we need to show there account age too.
         inline: false
     }]);
 });

--- a/src/structures/bbtag/Engine.js
+++ b/src/structures/bbtag/Engine.js
@@ -232,7 +232,7 @@ async function runTag(content, context) {
         let cdDate = context.cooldowns[context.tagName] + (context.cooldown || 0);
         let diff = Date.now() - cdDate;
         if (diff < 0) {
-            let retry_after = Math.floor((Date.now() + diff) / 1000);
+            let retry_after = Math.floor(cdDate / 1000);
             await bu.send(context.msg, `This ${context.isCC ? 'custom command' : 'tag'} is currently under cooldown. Please try again in <t:${retry_after}:R> seconds.`);
             return;
         }

--- a/src/structures/bbtag/Engine.js
+++ b/src/structures/bbtag/Engine.js
@@ -232,8 +232,8 @@ async function runTag(content, context) {
         let cdDate = context.cooldowns[context.tagName] + (context.cooldown || 0);
         let diff = Date.now() - cdDate;
         if (diff < 0) {
-            let f = Math.floor(diff / 100) / 10;
-            await bu.send(context.msg, `This ${context.isCC ? 'tag' : 'custom command'} is currently under cooldown. Please try again in ${f * -1} seconds.`);
+            let retry_after = Math.floor((Date.now() + diff) / 1000);
+            await bu.send(context.msg, `This ${context.isCC ? 'custom command' : 'tag'} is currently under cooldown. Please try again in <t:${retry_after}:R> seconds.`);
             return;
         }
     }

--- a/src/structures/bbtag/Engine.js
+++ b/src/structures/bbtag/Engine.js
@@ -233,7 +233,7 @@ async function runTag(content, context) {
         let diff = Date.now() - cdDate;
         if (diff < 0) {
             let retry_after = Math.floor(cdDate / 1000);
-            await bu.send(context.msg, `This ${context.isCC ? 'custom command' : 'tag'} is currently under cooldown. Please try again in <t:${retry_after}:R> seconds.`);
+            await bu.send(context.msg, `This ${context.isCC ? 'custom command' : 'tag'} is currently under cooldown. Please try again <t:${retry_after}:R>.`);
             return;
         }
     }


### PR DESCRIPTION
In this pull request I aimed to replace `moment().humanize()` to discord Timestamp that prevents blargbot to calculate humanized time and these also **Dynamic** with time in discord UI. This is how they look:
![image](https://user-images.githubusercontent.com/84070263/128823668-559367dd-8826-4e18-aca8-e1fe72127538.png)