### PR TITLE
Add context overrides to apply

### DIFF
--- a/src/tags/apply.js
+++ b/src/tags/apply.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 18:25:58
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-06-15 19:23:19
+ * @Last Modified time: 2021-08-13 00:37:30
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -12,8 +12,8 @@ const Builder = require('../structures/TagBuilder'),
 
 module.exports =
     Builder.ArrayTag('apply')
-        .withArgs(a => [a.require('subtag'), a.optional('args', true)])
-        .withDesc('Executes `subtag`, using the `args` as parameters. ' +
+        .withArgs(a => [a.require([a.optional('subtag'), a.optional('function')]), a.optional('args', true)])
+        .withDesc('Executes `subtag` or `function`, using the `args` as parameters. ' +
         'If `args` is an array, it will get deconstructed to it\'s individual elements.'
         ).withExample(
         '{apply;randint;[1,4]}',
@@ -21,9 +21,17 @@ module.exports =
         )
         .whenArgs(0, Builder.errors.notEnoughArguments)
         .whenDefault(async function (subtag, context, args) {
-            let definition = TagManager.get(args[0].toLowerCase());
-            if (definition == null)
+            let runSubtag;
+            const name = args[0].toLowerCase();
+            if (context.state.overrides.hasOwnProperty(name)) {
+                runSubtag = context.state.overrides[name];
+            } else {
+                const tagDefinition = TagManager.get(name) || {};
+                runSubtag = context.state.overrides[tagDefinition.name] || tagDefinition.execute;
+            }
+            if (runSubtag === undefined)
                 return Builder.util.error(subtag, context, 'No subtag found');
+
 
             let st = new SubTag(subtag);
 
@@ -38,7 +46,7 @@ module.exports =
                 st._protected.children.push(a);
             }
 
-            let result = await definition.execute(st, context);
+            let result = await runSubtag(st, context);
 
             return result;
         })

--- a/src/tags/apply.js
+++ b/src/tags/apply.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 18:25:58
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-08-13 00:37:30
+ * @Last Modified time: 2021-08-13 00:52:53
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -14,7 +14,8 @@ module.exports =
     Builder.ArrayTag('apply')
         .withArgs(a => [a.require([a.optional('subtag'), a.optional('function')]), a.optional('args', true)])
         .withDesc('Executes `subtag` or `function`, using the `args` as parameters. ' +
-        'If `args` is an array, it will get deconstructed to it\'s individual elements.'
+            'If `args` is an array, it will get deconstructed to it\'s individual elements.\n' +
+            '`function` must be of the format `func.<name>` eg: `{apply;func.hello;["world"]}`'
         ).withExample(
         '{apply;randint;[1,4]}',
         '3'

--- a/src/tags/apply.js
+++ b/src/tags/apply.js
@@ -30,7 +30,7 @@ module.exports =
                 const tagDefinition = TagManager.get(name) || {};
                 runSubtag = context.state.overrides[tagDefinition.name] || tagDefinition.execute;
             }
-            if (runSubtag === undefined)
+            if (runSubtag == null)
                 return Builder.util.error(subtag, context, 'No subtag found');
 
 


### PR DESCRIPTION
This PR was at first to allow the use of `{apply}` on `{function}`s, but this also happens to fix issues where users could use `{apply}` to 'bypass' context.overrides:
- `{apply}` can be used inside `{lock}` to nest them
- `{apply}` can be used inside `{filter}`/`{waitreaction}`/`{waitmessage}` to use disabled subtags.

This PR fixes these issues, and adds as mentioned before `func.name` functionality.
This also allows `apply` to execute subtags like `{reactuser}`/`{reaction}`/`{params}`/`{paramsarray}`/`{paramslength}`.