### PR TITLE
Allow calling {json} without arguments for empty an json

### DIFF
--- a/src/tags/json.js
+++ b/src/tags/json.js
@@ -12,13 +12,13 @@ const Builder = require('../structures/TagBuilder');
 module.exports =
     Builder.ArrayTag('json')
         .withAlias('j')
-        .withArgs(a => [a.require('input')])
-        .withDesc('Defines a raw JSON object without using subtags.')
+        .withArgs(a => [a.optional('input')])
+        .withDesc('Defines a raw JSON object without using subtags. If `input` is omitted, this will return an empty JSON object.')
         .withExample(
             '{json;{\n  "key": "value"\n}}',
             '{\n  "key": "value"\n}'
         ).resolveArgs(-1)
-        .whenArgs(0, Builder.errors.notEnoughArguments)
+        .whenArgs(0, () => '{}')
         .whenArgs(1, async function (subtag, context, args) {
             let raw = args[0].content;
             try {


### PR DESCRIPTION
Small QOL change for `{json}`. It feels better to use `{json}`/`{j}` than `{json;{}}`/`{j;{}}`

**Changed**:
- `input` is now optional