### PR TITLE
Added tagauthor and authorizer subtags

### DIFF
--- a/src/tags/tagauthor.js
+++ b/src/tags/tagauthor.js
@@ -1,0 +1,18 @@
+/*
+ * @Author: RagingLink
+ * @Date: 2021-08-20 19:09:50
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-08-20 19:15:53
+ */
+
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.SimpleTag('tagauthor')
+        .withAlias('ccauthor')
+        .withDesc('Returns the user ID of the tag/cc author')
+        .withExample(
+            'This tag was created by {username;{tagauthor}}',
+            'This tag was created by stupid cat'
+        ).whenDefault((_, context) => context.author)
+    .build();

--- a/src/tags/tagauthorizer.js
+++ b/src/tags/tagauthorizer.js
@@ -1,0 +1,18 @@
+/*
+ * @Author: RagingLink
+ * @Date: 2021-08-20 19:09:50
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-08-20 19:15:57
+ */
+
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.SimpleTag('tagauthorizer')
+        .withAlias('ccauthorizer')
+        .withDesc('Returns the user ID of the tag/cc authorizer')
+        .withExample(
+            '{username;{tagauthorizer}} authorized this tag!',
+            'stupid cat authorized this tag!'
+        ).whenDefault((_, context) => context.authorizer)
+    .build();


### PR DESCRIPTION
Some very simple subtags to return the `author` and `authorizer` of the executing tag/cc.
With aliases `ccauthor` and `ccauthorizer` to prevent confusion regarding tags and CCs.

Stems from discord question:
![afbeelding](https://user-images.githubusercontent.com/15198000/130270586-5d4364d2-c2e9-4ff7-95d7-f4ea197b3f8e.png)

**Added:**
- `{tagauthor}` and `{tagauthorizer}`