### PR TITLE
Allow ignoring of webhooks if a valid webhook ID is provided

### DIFF
--- a/src/dcommands/log.js
+++ b/src/dcommands/log.js
@@ -32,7 +32,7 @@ class LogCommand extends BaseCommand {
                 '\n- all - enables all of the events' +
                 '\n\n`ignore` adds a list of users to ignore from logging. Useful for ignoring bots.' +
                 '\n`track` removes users from the ignore list' +
-                '\n**Note:** When a webhook is provided for `users`, I must the `Manage Webhooks` permission to recognize them!'
+                '\n**Note:** When a webhook is provided for `users`, I must have the `Manage Webhooks` permission to recognize them!'
         });
     }
 


### PR DESCRIPTION
Added support for ignoring webhooks in `b!log`. This silently fails if blarg doesn't have the `Manage Webhooks` permission.

**Added:**
- Additional check for webhooks in `b!log`

![image](https://user-images.githubusercontent.com/15198000/130366023-f285e9b4-a1d0-4edc-88b6-cd4c8ecd54bf.png)
The initial suggestion mentioned including webhooks in user parsing (like bu.getUser), but I fear that might break stuff that relies on user-specific fields. So I added basic support for `b!log` only.