### PR TITLE
Changing architecture of kick & ban dcommand and tag

### DIFF
--- a/src/dcommands/ban.js
+++ b/src/dcommands/ban.js
@@ -21,7 +21,7 @@ class BanCommand extends BaseCommand {
         if (words[1]) {
             let input = bu.parseInput(this.flags, words);
 
-            var user = await bu.getUser(msg, input.undefined[0]);
+            let user = await bu.getUser(msg, input.undefined[0]);
             if (!user) {
                 return await bu.send(msg, `I couldn't find that user. Try again with their ID or a mention instead.`);
                 // bu.send(msg, `I couldn't find that user. Try using \`hackban\` with their ID or a mention instead.`);
@@ -52,9 +52,9 @@ class BanCommand extends BaseCommand {
         let member = msg.guild.members.get(user.id);
 
         if (member) {
-            var botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
-            var userPos = bu.getPosition(msg.member);
-            var targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
+            let botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
+            let userPos = bu.getPosition(msg.member);
+            let targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
             if (targetPos >= botPos) {
                 return [`I don't have permission to ban ${user.username}!`, '`Bot has no permissions`'];
             }
@@ -86,7 +86,7 @@ class BanCommand extends BaseCommand {
                     endtime: r.epochTime(moment().add(duration).unix()),
                     starttime: r.epochTime(moment().unix())
                 });
-                return [`:ok_hand: The user will be unbanned ${duration.humanize(true)}.`, duration.asMilliseconds()];
+                return [`:ok_hand: The user will be unbanned ${duration.humanize(true)}. Ban reason: ${reason}`, duration.asMilliseconds()];
             } else {
                 return [`:ok_hand:`, true];
             }

--- a/src/dcommands/ban.js
+++ b/src/dcommands/ban.js
@@ -86,7 +86,7 @@ class BanCommand extends BaseCommand {
                     endtime: r.epochTime(moment().add(duration).unix()),
                     starttime: r.epochTime(moment().unix())
                 });
-                return [`:ok_hand: The user will be unbanned ${duration.humanize(true)}. Ban reason: ${reason}`, duration.asMilliseconds()];
+                return [`:ok_hand: The user will be unbanned at <t:${unban_at}:F> (<t:${unban_at}:R>). Ban reason: ${reason}`, duration.asMilliseconds()];
             } else {
                 return [`:ok_hand:`, true];
             }

--- a/src/dcommands/ban.js
+++ b/src/dcommands/ban.js
@@ -21,7 +21,7 @@ class BanCommand extends BaseCommand {
         if (words[1]) {
             let input = bu.parseInput(this.flags, words);
 
-            let user = await bu.getUser(msg, input.undefined[0]);
+            const user = await bu.getUser(msg, input.undefined[0]);
             if (!user) {
                 return await bu.send(msg, `I couldn't find that user. Try again with their ID or a mention instead.`);
                 // bu.send(msg, `I couldn't find that user. Try using \`hackban\` with their ID or a mention instead.`);
@@ -52,9 +52,9 @@ class BanCommand extends BaseCommand {
         let member = msg.guild.members.get(user.id);
 
         if (member) {
-            let botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
-            let userPos = bu.getPosition(msg.member);
-            let targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
+            const botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
+            const userPos = bu.getPosition(msg.member);
+            const targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
             if (targetPos >= botPos) {
                 return [`I don't have permission to ban ${user.username}!`, '`Bot has no permissions`'];
             }

--- a/src/dcommands/kick.js
+++ b/src/dcommands/kick.js
@@ -21,12 +21,12 @@ class KickCommand extends BaseCommand {
             }
             if (!context.guild.members.get(user.id)) return this.userNotInGuild(subtag, context);   //checking if user is in guild; if not then returning user not in guild error
             
-            let target = await bu.getUser(msg, words[1]);
+            let target = await bu.getUser(msg, words[1]);     //unused
             let reason = bu.parseInput(this.flags, words).r;
 
             if (!target) return;
 
-            let state = await this.kick(msg, target, reason, false, false);
+            /*let state = await this.kick(msg, target, reason, false, false);
             let response;
             switch (state) {
                 case 0: //Successful
@@ -47,27 +47,37 @@ class KickCommand extends BaseCommand {
                 default: //Error occurred
                     response = `Failed to kick the user! Please check your permission settings and command and retry. \nIf you still can't get it to work, please report it to me by doing \`b!report <your issue>\` with the following:\`\`\`\n${state.message}\n${state.response}\`\`\``;
                     break;
-        }
+            }
 
-        bu.send(msg, response);
+            bu.send(msg, response);*/
+            
+            bu.send(await this.kick(msg, user, reason));
             
         } else bu.send(msg, `You didn't tell me who to kick!`);
     }
 
-    async kick(msg, target, reason, tag = false, noPerms = false) {
-        if (!msg.channel.guild.members.get(bot.user.id).permissions.json.kickMembers)
-            return 1;
+    async kick(msg, user, reason, tag = false, noPerms = false) {
+        if (!msg.channel.guild.members.get(bot.user.id).permissions.json.kickMembers) {
+            return [`I don't have permission to kick users!`, '`Bot has no permissions`'];
+        }
         let kickPerms = await bu.guildSettings.get(msg.guild.id, 'kickoverride') || 0;
-        if (!noPerms && !bu.comparePerms(msg.member, kickPerms) && !msg.member.permissions.json.kickMembers)
-            return 3;
-
-        var botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
-        var userPos = bu.getPosition(msg.member);
-        var targetPos = bu.getPosition(msg.channel.guild.members.get(target.id));
-        if (targetPos >= botPos)
-            return 2;
-        if (!noPerms && targetPos >= userPos && msg.author.id != msg.guild.ownerID)
-            return 4;
+        if (!noPerms && !bu.comparePerms(msg.member, kickPerms) && !msg.member.permissions.json.kickMembers) {
+            return [`You don't have permission to ban users!`, '`User has no permissions`'];
+        }
+        
+        let member = msg.guild.members.get(user.id);
+        
+        if(member) {
+            var botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
+            var userPos = bu.getPosition(msg.member);
+            var targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
+            if (targetPos >= botPos) {
+                return [`I don't have permission to kick ${user.username}!`, '`Bot has no permissions`'];
+            }
+            if (!noPerms && targetPos >= userPos && msg.author.id != msg.guild.ownerID) {
+                return [`You don't have permission to kick ${user.username}!`, '`User has no permissions`'];
+            }
+        }
 
         try {
             const fullReason = encodeURIComponent((tag ? '' : `[ ${bu.getFullName(msg.author)} ]`)
@@ -79,11 +89,11 @@ class KickCommand extends BaseCommand {
                 fullReason
             );
 
-            return 0;
-        }
-        catch (err) {
-            console.error(err);
-            return err;
+            return [`:ok_hand: Kicked ${user.username}. Reason: ${reason}`];
+        } catch (err) {
+            //console.error(err);
+            //return err;
+            return [`Failed to kick the user! Please check your permission settings and command and retry. \nIf you still can't get it to work, please report it to me by doing \`b!report <your issue>\` with the following:\`\`\`\n${err.message}\n${err.response}\`\`\``, false];
         }
     }
 }

--- a/src/dcommands/kick.js
+++ b/src/dcommands/kick.js
@@ -51,7 +51,7 @@ class KickCommand extends BaseCommand {
 
             bu.send(msg, response);*/
             
-            bu.send(await this.kick(msg, user, reason));
+            bu.send((await this.kick(msg, user, reason))[0]);
             
         } else bu.send(msg, `You didn't tell me who to kick!`);
     }
@@ -62,21 +62,22 @@ class KickCommand extends BaseCommand {
         }
         let kickPerms = await bu.guildSettings.get(msg.guild.id, 'kickoverride') || 0;
         if (!noPerms && !bu.comparePerms(msg.member, kickPerms) && !msg.member.permissions.json.kickMembers) {
-            return [`You don't have permission to ban users!`, '`User has no permissions`'];
+            return [`You don't have permission to kick users!`, '`User has no permissions`'];
         }
         
         let member = msg.guild.members.get(user.id);
         
-        if(member) {
-            let botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
-            let userPos = bu.getPosition(msg.member);
-            let targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
-            if (targetPos >= botPos) {
-                return [`I don't have permission to kick ${user.username}!`, '`Bot has no permissions`'];
-            }
-            if (!noPerms && targetPos >= userPos && msg.author.id != msg.guild.ownerID) {
-                return [`You don't have permission to kick ${user.username}!`, '`User has no permissions`'];
-            }
+        if(!member) {
+            return [`${user.username} isnt on this server!`, '`User not in guild`'];
+        }
+        let botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
+        let userPos = bu.getPosition(msg.member);
+        let targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
+        if (targetPos >= botPos) {
+            return [`I don't have permission to kick ${user.username}!`, '`Bot has no permissions`'];
+        }
+        if (!noPerms && targetPos >= userPos && msg.author.id != msg.guild.ownerID) {
+            return [`You don't have permission to kick ${user.username}!`, '`User has no permissions`'];
         }
 
         try {
@@ -91,7 +92,7 @@ class KickCommand extends BaseCommand {
 
             return [`:ok_hand: Kicked ${user.username}. Reason: ${reason}`];
         } catch (err) {
-            //console.error(err);
+            console.error(err);
             //return err;
             return [`Failed to kick the user! Please check your permission settings and command and retry. \nIf you still can't get it to work, please report it to me by doing \`b!report <your issue>\` with the following:\`\`\`\n${err.message}\n${err.response}\`\`\``, false];
         }

--- a/src/dcommands/kick.js
+++ b/src/dcommands/kick.js
@@ -25,7 +25,7 @@ class KickCommand extends BaseCommand {
 
             if (!target) return;
             
-            bu.send((await this.kick(msg, user, reason))[0]);
+            bu.send(msg, (await this.kick(msg, user, reason))[0]);
             
         } else bu.send(msg, `You didn't tell me who to kick!`);
     }
@@ -64,11 +64,13 @@ class KickCommand extends BaseCommand {
                 fullReason
             );
 
-            return [`:ok_hand: Kicked ${user.username}. Reason: ${reason}`];
+            if (reason)
+                return [`:ok_hand: Kicked ${user.username}. Reason: ${reason}`, 'Success'];
+            return [`:ok_hand: Kicked ${user.username}.`, 'Success'];
         } catch (err) {
             console.error(err);
             //return err;
-            return [`Failed to kick the user! Please check your permission settings and command and retry. \nIf you still can't get it to work, please report it to me by doing \`b!report <your issue>\` with the following:\`\`\`\n${err.message}\n${err.response}\`\`\``, false];
+            return [`Failed to kick the user! Please check your permission settings and command and retry. \nIf you still can't get it to work, please report it to me by doing \`b!report <your issue>\` with the following:\`\`\`\n${err.message}\n${err.response}\`\`\``, err];
         }
     }
 }

--- a/src/dcommands/kick.js
+++ b/src/dcommands/kick.js
@@ -24,31 +24,6 @@ class KickCommand extends BaseCommand {
             let reason = bu.parseInput(this.flags, words).r;
 
             if (!target) return;
-
-            /*let state = await this.kick(msg, target, reason, false, false);
-            let response;
-            switch (state) {
-                case 0: //Successful
-                    response = `Kicked ${target.username}. Reason: ${reason}`;
-                    break;
-                case 1: //Bot doesnt have perms
-                    response = `I don't have permission to kick users!`;
-                    break;
-                case 2: //Bot cannot kick target
-                    response = `I don't have permission to kick ${target.username}!`;
-                break;
-                case 3: //User doesnt have perms
-                    response = `You don't have permission to kick users!`;
-                    break;
-                case 4: //User cannot kick target
-                    response = `You don't have permission to kick ${target.username}!`;
-                    break;
-                default: //Error occurred
-                    response = `Failed to kick the user! Please check your permission settings and command and retry. \nIf you still can't get it to work, please report it to me by doing \`b!report <your issue>\` with the following:\`\`\`\n${state.message}\n${state.response}\`\`\``;
-                    break;
-            }
-
-            bu.send(msg, response);*/
             
             bu.send((await this.kick(msg, user, reason))[0]);
             
@@ -85,7 +60,7 @@ class KickCommand extends BaseCommand {
 
             await bot.kickGuildMember(
                 msg.channel.guild.id,
-                target.id,
+                member.id,
                 fullReason
             );
 

--- a/src/dcommands/kick.js
+++ b/src/dcommands/kick.js
@@ -19,7 +19,6 @@ class KickCommand extends BaseCommand {
             if (!user) {
                 return await bu.send(msg, `I couldn't find that user. Try again with their ID or a mention instead.`);
             }
-            if (!context.guild.members.get(user.id)) return this.userNotInGuild(subtag, context);   //checking if user is in guild; if not then returning user not in guild error
             
             let target = await bu.getUser(msg, words[1]);     //unused
             let reason = bu.parseInput(this.flags, words).r;

--- a/src/dcommands/kick.js
+++ b/src/dcommands/kick.js
@@ -15,7 +15,7 @@ class KickCommand extends BaseCommand {
         if (words[1]) {
             let input = bu.parseInput(this.flags, words);
             
-            var user = await bu.getUser(msg, input.undefined[0]);
+            let user = await bu.getUser(msg, input.undefined[0]);
             if (!user) {
                 return await bu.send(msg, `I couldn't find that user. Try again with their ID or a mention instead.`);
             }
@@ -68,9 +68,9 @@ class KickCommand extends BaseCommand {
         let member = msg.guild.members.get(user.id);
         
         if(member) {
-            var botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
-            var userPos = bu.getPosition(msg.member);
-            var targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
+            let botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
+            let userPos = bu.getPosition(msg.member);
+            let targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
             if (targetPos >= botPos) {
                 return [`I don't have permission to kick ${user.username}!`, '`Bot has no permissions`'];
             }

--- a/src/dcommands/kick.js
+++ b/src/dcommands/kick.js
@@ -65,14 +65,14 @@ class KickCommand extends BaseCommand {
             return [`You don't have permission to kick users!`, '`User has no permissions`'];
         }
         
-        let member = msg.guild.members.get(user.id);
+        const member = msg.guild.members.get(user.id);
         
         if(!member) {
             return [`${user.username} isnt on this server!`, '`User not in guild`'];
         }
-        let botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
-        let userPos = bu.getPosition(msg.member);
-        let targetPos = bu.getPosition(msg.channel.guild.members.get(user.id));
+        const botPos = bu.getPosition(msg.channel.guild.members.get(bot.user.id));
+        const userPos = bu.getPosition(msg.member);
+        const targetPos = bu.getPosition(member);
         if (targetPos >= botPos) {
             return [`I don't have permission to kick ${user.username}!`, '`Bot has no permissions`'];
         }

--- a/src/tags/kick.js
+++ b/src/tags/kick.js
@@ -35,17 +35,33 @@ module.exports =
 
             if (!user) return Builder.errors.noUserFound(subtag, context);
 
-            let state = await CommandManager.built['kick'].kick(
+            let response = await CommandManager.built['kick'].kick(
                 context.msg,
                 user,
                 args[1] || context.scope.reason || undefined,
                 true,
                 noPerms
             );
-            if (typeof state[1] == 'string' && state[1].startsWith('`'))
-                return Builder.util.error(subtag, context, state[1]);
+            /*console.debug(state);
+            switch (state) {
+                case 0: //Successful
+                    return 'Success';
+                case 1: //Bot doesnt have perms
+                    return error(`I don't have permission to kick users!`);
+                case 2: //Bot cannot kick target
+                    return error(`I don't have permission to kick ${user.username}!`);
+                case 3: //User doesnt have perms
+                    return error(`You don't have permission to kick users!`);
+                case 4: //User cannot kick target
+                    return error(`You don't have permission to kick ${user.username}!`);
+                default: //Error occurred
+                    throw state;
+            }*/
     
-            return state[1];
+            if (typeof response[1] == 'string' && response[1].startsWith('`'))
+                return Builder.util.error(subtag, context, response[1]);
+    
+            return response[1];
         })
         .whenDefault(Builder.errors.tooManyArguments)
         .build();

--- a/src/tags/kick.js
+++ b/src/tags/kick.js
@@ -42,24 +42,11 @@ module.exports =
                 true,
                 noPerms
             );
-            /*console.debug(state);
-            switch (state) {
-                case 0: //Successful
-                    return 'Success';
-                case 1: //Bot doesnt have perms
-                    return error(`I don't have permission to kick users!`);
-                case 2: //Bot cannot kick target
-                    return error(`I don't have permission to kick ${user.username}!`);
-                case 3: //User doesnt have perms
-                    return error(`You don't have permission to kick users!`);
-                case 4: //User cannot kick target
-                    return error(`You don't have permission to kick ${user.username}!`);
-                default: //Error occurred
-                    throw state;
-            }*/
     
-            if (typeof response[1] == 'string' && response[1].startsWith('`'))
-                return Builder.util.error(subtag, context, response[1]);
+            if (typeof response[1] != 'string')
+                throw response[1];
+            if (response[1].startsWith('`'))
+                return Builder.util.error(subtag, context, response[1].slice(1, -1));
     
             return response[1];
         })

--- a/src/tags/kick.js
+++ b/src/tags/kick.js
@@ -42,21 +42,9 @@ module.exports =
                 true,
                 noPerms
             );
-            console.debug(state);
-            switch (state) {
-                case 0: //Successful
-                    return 'Success';
-                case 1: //Bot doesnt have perms
-                    return error(`I don't have permission to kick users!`);
-                case 2: //Bot cannot kick target
-                    return error(`I don't have permission to kick ${user.username}!`);
-                case 3: //User doesnt have perms
-                    return error(`You don't have permission to kick users!`);
-                case 4: //User cannot kick target
-                    return error(`You don't have permission to kick ${user.username}!`);
-                default: //Error occurred
-                    throw state;
-            }
+            if (typeof response[1] == 'string' && response[1].startsWith('`'))
+            return Builder.util.error(subtag, context, response[1]);
+            return response[1];
         })
         .whenDefault(Builder.errors.tooManyArguments)
         .build();

--- a/src/tags/kick.js
+++ b/src/tags/kick.js
@@ -42,9 +42,10 @@ module.exports =
                 true,
                 noPerms
             );
-            if (typeof response[1] == 'string' && response[1].startsWith('`'))
-            return Builder.util.error(subtag, context, response[1]);
-            return response[1];
+            if (typeof state[1] == 'string' && state[1].startsWith('`'))
+                return Builder.util.error(subtag, context, state[1]);
+    
+            return state[1];
         })
         .whenDefault(Builder.errors.tooManyArguments)
         .build();


### PR DESCRIPTION
~~This should (I hope) fix void not supressing kick errors by changing the way they're handled from old switch to something similar to how ban subtag's errors are handled.~~

This pull request is supposed to change the architecture of ban and kick tag and default command. Both of them used completely different logic making it confusing. They are now both made in the better way (taken from ban tag and dcommand). This PR also contains other improvements, e. g. adding better replies to the commands.

**Change Log**
- Changed variable initialization system to use newer `let` instead of old `var`
- Changed variable names in kick dcommand & tag to make them same as in ban dcommand and tag
- Changed return types & values in kick command replacing numbers reprising the state with strings explaining the state
- Changed ban and kick commands' replies adding reason to them
- Added the code responsible for checking whether the user is on the guild or not to kick command fixing an issue causing an internal server error
- Replaced `moment#humanize` with discord timestamps