### PR TITLE
Fixes custom authorizer being ignored in ars and {exec/cc}

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -2,7 +2,7 @@
  * @Author: stupid cat
  * @Date: 2017-05-07 18:22:24
  * @Last Modified by: RagingLink
- * @Last Modified time: 2021-08-03 12:08:32
+ * @Last Modified time: 2021-09-25 22:51:31
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -517,6 +517,7 @@ async function handleAutoresponse(msg, storedGuild, everything = false) {
                 limits: new bbtag.limits.autoresponse_everything(),
                 tagContent: tag.content,
                 author: tag.author,
+                authorizer: tag.authorizer,
                 input: m.content,
                 isCC: true,
                 tagName: ars.everything.executes,
@@ -552,6 +553,7 @@ async function handleAutoresponse(msg, storedGuild, everything = false) {
                         limits: new bbtag.limits.autoresponse_general(),
                         tagContent: tag.content,
                         author: tag.author,
+                        authorizer: tag.authorizer,
                         input: matches || m.content,
                         isCC: true,
                         tagName: ar.executes

--- a/src/structures/bbtag/Context.js
+++ b/src/structures/bbtag/Context.js
@@ -121,6 +121,7 @@ class Context {
         if (options.isCC === undefined) options.isCC = this.isCC;
         if (options.tagName === undefined) options.tagName = this.tagName;
         if (options.author === undefined) options.author = this.author;
+        if (options.authorizer === undefined) options.authorizer = this.authorizer;
         if (options.locks === undefined) options.locks = this.locks;
         if (options.outputModify === undefined) options.outputModify = this.outputModify;
 


### PR DESCRIPTION
Fixes `context.makeChild()` not using `this.authorizer` of the 'parent' context, and adds the `authorizer` option to autoresponses in case they are different.

Fixes AT bug report [#758](https://blargbot.xyz/feedback/rec7DzGDoiYRKH7kG)

**Changed:**
- `options.authorizer` is now set to `this.authorizer` in `context.makeChild()`
- autoresponses now respect differing author + authorizer [ae6acfd](https://github.com/blargbot/blargbot/commit/ae6acfdfbfc11506469ae52fd234b7cab2407bb6)

Additional context:
![image](https://user-images.githubusercontent.com/15198000/134786042-0a397524-723a-44a3-bc6c-28bb7180bd76.png)
![image](https://user-images.githubusercontent.com/15198000/134786044-49d7e05a-9bac-4fc0-a31e-4f8426ed025a.png)
