### PR TITLE
Fixed discrepancy between ban docs and code

### DIFF
--- a/src/dcommands/ban.js
+++ b/src/dcommands/ban.js
@@ -7,7 +7,7 @@ class BanCommand extends BaseCommand {
             name: 'ban',
             category: bu.CommandType.ADMIN,
             usage: 'ban <user> [days] [flags]',
-            info: 'Bans a user, where `days` is the number of days to delete messages for (defaults to 1).\nIf mod-logging is enabled, the ban will be logged.',
+            info: 'Bans a user, where `days` is the number of days to delete messages for (defaults to 1, with a maximum of 7).\nIf mod-logging is enabled, the ban will be logged.',
             flags: [{ flag: 'r', word: 'reason', desc: 'The reason for the ban.' },
             {
                 flag: 't',


### PR DESCRIPTION
Fixed discrepancy between the docs of `b!ban` saying it defaults to "1 day" and the code saying it's `0`