### PR TITLE
Use discord ban reason if not provided

### DIFF
--- a/src/events/guildBanAdd.js
+++ b/src/events/guildBanAdd.js
@@ -1,8 +1,8 @@
 /*
  * @Author: stupid cat
  * @Date: 2017-05-07 18:21:12
- * @Last Modified by: stupid cat
- * @Last Modified time: 2017-05-07 18:21:12
+ * @Last Modified by: RagingLink
+ * @Last Modified time: 2021-10-21 15:22:47
  *
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
@@ -41,6 +41,15 @@ bot.on('guildBanAdd', async function (guild, user) {
         type = bu.bans[guild.id][user.id].type;
         reason = bu.bans[guild.id][user.id].reason;
         delete bu.bans[guild.id][user.id];
+    }
+    if (reason === undefined) {
+        try {
+            const banObject = await guild.getBan(user.id);
+            if (banObject !== undefined)
+                reason = banObject.reason;
+        } catch (e) {
+            //no-op
+        }
     }
     bu.logAction(guild, user, mod, type, reason, bu.ModLogColour.BAN);
     bu.logEvent(guild.id, user.id, 'memberban', [{


### PR DESCRIPTION
If a member gets banned by another bot/user with their own reason, blarg defaults to `Responsible moderator, please do reason ${caseid} to set.`. 
This PR allows blarg to use the ban reason set by another user/bot, which should prevent users having to update blarg's modlog entry manually.

Per **Felix Argyle#7777**'s suggestion.

This change has been added to TS as well.