### PR TITLE
Feature: add new setting not to kick when out of the limit

### DIFF
--- a/src/dcommands/settings.js
+++ b/src/dcommands/settings.js
@@ -81,6 +81,11 @@ bu.settings = {
         desc: 'The number of warnings before a kick. Set to 0 or below to disable.',
         type: 'int'
     },
+    actonlimitsonly: {
+        name: 'Act on Limits Only',
+        desc: 'Whether to kick/ban on a warning count that is in between the kickat and banat values.',
+        type: 'bool'
+    },
     adminrole: {
         name: 'Admin Role Name',
         desc: 'The name of the Admin role.',
@@ -205,6 +210,7 @@ class SettingsCommand extends BaseCommand {
             let cleverbot = settings.nocleverbot || false;
             let kickAt = settings.kickat || 'Disabled';
             let banAt = settings.banat || 'Disabled';
+            let actonlimitsonly = settings.actonlimitsonly || false;
             let social = settings.social || 'Disabled';
             let adminRoleName = settings.adminrole || 'Admin';
             let embed = {
@@ -257,6 +263,7 @@ Kick Override : ${kickPerms}
                         value: `\`\`\`
 Kick At : ${kickAt}
  Ban At : ${banAt}
+ Act on Limits Only : ${actonlimitsonly}
 \`\`\``,
                         inline: true
                     },

--- a/src/utils/generic.js
+++ b/src/utils/generic.js
@@ -902,36 +902,49 @@ bu.issueWarning = async function (user, guild, count, params) {
     if (!storedGuild.warnings.users[user.id]) storedGuild.warnings.users[user.id] = 0;
     let type = 0;
     let error = undefined;
+    const oldCount = storedGuild.warnings.users[user.id];
     storedGuild.warnings.users[user.id] += count;
     if (storedGuild.warnings.users[user.id] < 0) storedGuild.warnings.users[user.id] = 0;
     let warningCount = storedGuild.warnings.users[user.id];
     const member = guild.members.get(user.id);
     if (member && bu.isBotHigher(member)) {
-        if (storedGuild.settings.banat && storedGuild.settings.banat > 0 && warningCount >= storedGuild.settings.banat) {
-            if (!bu.bans[guild.id]) bu.bans[guild.id] = {};
-            bu.bans[guild.id][user.id] = {
-                mod: bot.user,
-                type: 'Auto-Ban',
-                reason: `Exceeded Warning Limit (${warningCount}/${storedGuild.settings.banat})`
-            };
-            try {
-                await guild.banMember(user.id, 0, `[ Auto-Ban ] Exceeded warning limit (${warningCount}/${storedGuild.settings.banat})`);
-            } catch (e) { error = e; }
-            storedGuild.warnings.users[user.id] = undefined;
-            type = 1;
-        } else if (storedGuild.settings.kickat && storedGuild.settings.kickat > 0) {
-            if (!storedGuild.settings.actonlimitsonly && warningCount >= storedGuild.settings.kickat) {
-                try {
-                    await guild.kickMember(user.id, `[ Auto-Kick ] Exceeded warning limit (${warningCount}/${storedGuild.settings.kickat})`);
-                } catch (e) { error = e; }
-                type = 2;
-            } else if (storedGuild.settings.actonlimitsonly && warningCount == storedGuild.settings.kickat) {
-                try {
-                    await guild.kickMember(user.id, `[ Auto-Kick ] Exceeded warning limit (${warningCount}/${storedGuild.settings.kickat})`);
-                } catch (e) { error = e; }
-                type = 2;
-            }
-        }
+        if (
+			storedGuild.settings.banat &&
+			storedGuild.settings.banat > 0 &&
+			warningCount >= storedGuild.settings.banat
+		) {
+			if (!bu.bans[guild.id]) bu.bans[guild.id] = {};
+			bu.bans[guild.id][user.id] = {
+				mod: bot.user,
+				type: 'Auto-Ban',
+				reason: `Exceeded Warning Limit (${warningCount}/${storedGuild.settings.banat})`,
+			};
+			try {
+				await guild.banMember(
+					user.id,
+					0,
+					`[ Auto-Ban ] Exceeded warning limit (${warningCount}/${storedGuild.settings.banat})`
+				);
+			} catch (e) {
+				error = e;
+			}
+			storedGuild.warnings.users[user.id] = undefined;
+			type = 1;
+		} else if (
+			storedGuild.settings.kickat && storedGuild.settings.kickat > 0 &&
+			(!storedGuild.settings.actonlimitsonly || oldCount < storedGuild.settings.kickat) &&
+			warningCount >= storedGuild.settings.kickat
+		) {
+			try {
+				await guild.kickMember(
+					user.id,
+					`[ Auto-Kick ] Exceeded warning limit (${warningCount}/${storedGuild.settings.kickat})`
+				);
+			} catch (e) {
+				error = e;
+			}
+			type = 2;
+		}
     }
     await r.table('guild').get(guild.id).update({
         warnings: r.literal(storedGuild.warnings)


### PR DESCRIPTION
When a member is warned and they already have a count that is equal or greater than the kickat limit, the user is still kicked. 

## Introducing a new setting: actonlimitsonly !
If you want to handle this specific behavior, you now have two choices: 
- either keep the default one, which is to kick if the user's warning counts is in the bounds [kickat, banat]
- change to the new one, which is to kick only when the user's warning counts is equal to the kickat value or when the user reaches or exceeds the kickat value for the first warning

___

### Added
- New guild setting "actonlimitsonly" (boolean value)

### Changed
- Behavior when issuing a warning

Fixes #300 