### PR TITLE
Added subtag counter to metrics

### DIFF
--- a/src/core/Metrics.js
+++ b/src/core/Metrics.js
@@ -36,6 +36,11 @@ const commandLatency = new Prometheus.Histogram({
     buckets: [10, 100, 500, 1000, 2000, 5000]
 });
 
+const subtagCounter = new Prometheus.Counter({
+    name: 'bot_subtag_counter', help: 'Subtags executed',
+    labelNames: ['subtag']
+});
+
 const subtagLatency = new Prometheus.Histogram({
     name: 'bot_subtag_latency_ms', help: 'Latency of subtag execution',
     labelNames: ['subtag'],
@@ -65,7 +70,7 @@ const aggregate = function (regArray) {
 module.exports = {
     Prometheus, aggregate, guildGauge, shardStatus, userGauge, messageCounter,
     chatlogCounter, commandCounter, commandError, commandLatency, bbtagExecutions,
-    subtagLatency, httpsRequests,
+    subtagCounter, subtagLatency, httpsRequests,
     registryCache: [],
     get aggregated() {
         let c = module.exports.registryCache.filter(m => true);

--- a/src/structures/TagBuilder.js
+++ b/src/structures/TagBuilder.js
@@ -52,8 +52,8 @@ class TagBuilder {
                     let execArgs = resolveArgs != null
                         ? resolveArgs
                         : [...new Array(subtagArgs.length).keys()];
-
-                    for (const index of new Set(execArgs))
+                    
+                        for (const index of new Set(execArgs))
                         if (subtagArgs[index] !== undefined)
                             subtagArgs[index] = await definition.executeArg(subtag, subtagArgs[index], context);
 
@@ -78,6 +78,8 @@ class TagBuilder {
                     timer.end();
                     bu.Metrics.subtagLatency
                         .labels(subtag.name).observe(timer.elapsed);
+                    bu.Metrics.subtagCounter
+                        .labels(subtag.name).inc();
                     if (!context.state.subtags)
                         context.state.subtags = {};
                     if (!context.state.subtags[subtag.name] || !Array.isArray(context.state.subtags[subtag.name]))

--- a/src/structures/TagBuilder.js
+++ b/src/structures/TagBuilder.js
@@ -52,8 +52,8 @@ class TagBuilder {
                     let execArgs = resolveArgs != null
                         ? resolveArgs
                         : [...new Array(subtagArgs.length).keys()];
-                    
-                        for (const index of new Set(execArgs))
+
+                    for (const index of new Set(execArgs))
                         if (subtagArgs[index] !== undefined)
                             subtagArgs[index] = await definition.executeArg(subtag, subtagArgs[index], context);
 


### PR DESCRIPTION
As blargbot appears to be suffering from increased latency a bit more than usual, I figured it'd perhaps be useful to have a way of viewing the execution rate of (specific) subtags which would be possible with a simple prometheus counter.

**PS**: This change will require the master process to be restarted