### PR TITLE
Fix unknown message not being handled

### DIFF
--- a/src/structures/bbtag/Context.js
+++ b/src/structures/bbtag/Context.js
@@ -288,7 +288,9 @@ class Context {
         let msg;
         try {
             msg = await bu.getMessage(obj.msg.channel.id, obj.msg.id);
-        } catch (err) {
+        } catch (err) { /*no-op*/ };
+
+        if (!msg) {
             let channel = await bot.getChannel(obj.msg.channel.id);
             let member;
             if (channel == null) {
@@ -308,7 +310,8 @@ class Context {
                 attachments: obj.msg.attachments,
                 embeds: obj.msg.embeds
             };
-        }
+        };
+
         let result = new Context({
             msg,
             isCC: obj.isCC,


### PR DESCRIPTION
As `Context.serialize` now uses `bu.getMessage` instead of `bot.getMessage`, in cases when the original input message doesn't exist anymore it now doesn't throw an error for the `catch` to handle.

Fixes oversight made in commit [5f6af5d](https://github.com/blargbot/blargbot/commit/5f6af5dcf4577d9e73b6ee72ad505f2eb5514700)