### PR TITLE
Fix wrong syntax usage in bu.getMessage

### DIFF
--- a/src/utils/generic.js
+++ b/src/utils/generic.js
@@ -676,7 +676,7 @@ bu.getMessage = async function (channelId, messageId) {
         if (messageAttempt) return messageAttempt;
         try {
             const msg = await bot.getMessage(channelId, messageId);
-            channel.messages.set(msg);
+            channel.messages.add(msg);
             return msg;
         } catch (e) {
             console.error(e);


### PR DESCRIPTION
This fixes [airtable report #773](https://airtable.com/shrEUdEv4NM04Wi7O/tblyFuWE6fEAbaOfo/viwDg5WovcwMA9NIL/recDeTcTHyazvXh1W?blocks=bipip3uBZFRPcSy3C)