### PR TITLE
Show all variables in debug list

### DIFF
--- a/src/core/bbtag.js
+++ b/src/core/bbtag.js
@@ -354,7 +354,7 @@ function generateDebug(code, context) {
             let json = JSON.stringify(context.variables.cache[key].value);
             json.replace(/\n/, '\n' + offset);
             return key + ': ' + json;
-        }).slice(0, 24);
+        });
     let subtags = Object.keys(context.state.subtags).map(s => {
         return {
             name: s, times: context.state.subtags[s],


### PR DESCRIPTION
Resolves airtable suggestion [#373](https://airtable.com/appKTYe5luRw2aoas/tblyFuWE6fEAbaOfo/viwxsAP7dSkCUPzOn/rec1roxpCAD25Z1i9?blocks=hide)