### PR TITLE
Add flow control subtags, and content to {return}

### DIFF
--- a/src/structures/TagBuilder.js
+++ b/src/structures/TagBuilder.js
@@ -3,7 +3,8 @@ const ArgFactory = require('./ArgumentFactory'),
     Timer = require('./Timer'),
     { Permission } = require('eris'),
     Context = require('./bbtag/Context'),
-    { SubTag, BBTag } = require('./bbtag/Tag');
+    { SubTag, BBTag } = require('./bbtag/Tag'),
+    { FlowState } = require('./bbtag/FlowControl');
 
 (Context, SubTag, BBTag);
 
@@ -327,6 +328,13 @@ function buildLengthEmbed(definition, subtag, context) {
     };
 }
 
+/**
+ * @param {*} limit
+ * @param {*} subtag
+ * @param {*} arg
+ * @param {Context} context
+ * @returns
+ */
 async function executeArg(limit, subtag, arg, context) {
     let result = await bbEngine.execute(arg, context);
     if (typeof limit === 'number' && limit > 0) {
@@ -338,7 +346,7 @@ async function executeArg(limit, subtag, arg, context) {
                     ...buildLengthEmbed(this, subtag, context)
                 }
             });
-            context.state.return = -1;
+            context.state.flowState = FlowState.KILL_ALL;
             return TagBuilder.util.error(arg, context, 'Argument length exceeded limit');
         } else if (result.length > (limit / 2)) {
             bu.send('250859956989853696', {

--- a/src/structures/bbtag/BBTagError.js
+++ b/src/structures/bbtag/BBTagError.js
@@ -1,0 +1,7 @@
+class BBTagError extends Error {
+    constructor(message) {
+        super(message);
+    }
+}
+
+module.exports = { BBTagError };

--- a/src/structures/bbtag/Caching.js
+++ b/src/structures/bbtag/Caching.js
@@ -22,7 +22,9 @@ class VariableCache {
         this.cache = {};
     }
 
-    /** @param {string} variable The name of the variable to retrieve @returns {string}*/
+    /**
+     * @param {string} variable The name of the variable to retrieve
+     * @returns {Promise<string>}*/
     async get(variable) {
         let forced = variable.startsWith('!');
         if (forced) variable = variable.substr(1);

--- a/src/structures/bbtag/FlowControl.js
+++ b/src/structures/bbtag/FlowControl.js
@@ -1,0 +1,11 @@
+/** @enum {0|1|2|3|4|5} */
+const FlowState = {
+    /** @type {0} */NORMAL: 0,
+    /** @type {1} */KILL_ALL: 1,
+    /** @type {2} */KILL_TAG: 2,
+    /** @type {3} */KILL_FUNC: 3,
+    /** @type {4} */BREAK_LOOP: 4,
+    /** @type {5} */CONTINUE_LOOP: 5
+};
+
+module.exports = { FlowState };

--- a/src/tags/break.js
+++ b/src/tags/break.js
@@ -1,0 +1,25 @@
+/*
+ * @Author: stupid cat
+ * @Date: 2017-05-07 18:54:23
+ * @Last Modified by: stupid cat
+ * @Last Modified time: 2017-05-07 18:54:23
+ *
+ * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
+ */
+
+const { FlowState } = require('../structures/bbtag/FlowControl');
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.AutoTag('break')
+        .withArgs(a => [])
+        .withDesc('Breaks the currently running loop, regardless of its progress.')
+        .withExample(
+            '{unindent;{for;~i;0;<;10;\n    {get;~i}\n    {if;{get;~i};>;3;{break}}\n}}',
+            '0\n1\n2\n3\n4'
+        )
+        .whenArgs('0', async function (subtag, context) {
+            context.state.flowState = FlowState.BREAK_LOOP;
+        })
+        .whenDefault(Builder.errors.tooManyArguments)
+        .build();

--- a/src/tags/continue.js
+++ b/src/tags/continue.js
@@ -1,0 +1,25 @@
+/*
+ * @Author: stupid cat
+ * @Date: 2017-05-07 18:54:23
+ * @Last Modified by: stupid cat
+ * @Last Modified time: 2017-05-07 18:54:23
+ *
+ * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
+ */
+
+const { FlowState } = require('../structures/bbtag/FlowControl');
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.AutoTag('continue')
+        .withArgs(a => [])
+        .withDesc('Skips to the next loop, regardless of its progress.')
+        .withExample(
+            '{unindent;{for;~i;0;<;10;\n    {if;{math;%;{get;~i};3};==;1;{continue}}\n    {get;~i}\n}}',
+            '0\n2\n3\n5\n6\n8\n9'
+        )
+        .whenArgs('0', async function (subtag, context) {
+            context.state.flowState = FlowState.CONTINUE_LOOP;
+        })
+        .whenDefault(Builder.errors.tooManyArguments)
+        .build();

--- a/src/tags/foreach.js
+++ b/src/tags/foreach.js
@@ -7,6 +7,7 @@
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
 
+const { FlowState } = require('../structures/bbtag/FlowControl');
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
@@ -30,16 +31,28 @@ module.exports =
 
             let remaining = context.state.limits.foreach || { loops: NaN };
 
+            loop:
             for (const item of array) {
                 remaining.loops--;
-                if (!(remaining.loops >= 0)) { // (remaining.loops < 0) would not work due to the comparison behaviours of NaN
+                if (!(remaining.loops >= 0)) { // (remaining.loops < 0) would not work due to the comparison behaviors of NaN
                     result += Builder.errors.tooManyLoops(subtag, context);
                     break;
                 }
                 await context.variables.set(varName, item);
                 result += await this.executeArg(subtag, args[2], context);
-                if (context.state.return)
-                    break;
+
+                switch (context.state.flowState) {
+                    case FlowState.NORMAL:
+                        break;
+                    case FlowState.CONTINUE_LOOP:
+                        context.state.flowState = FlowState.NORMAL;
+                        continue loop;
+                    case FlowState.BREAK_LOOP:
+                        context.state.flowState = FlowState.NORMAL;
+                    //Fallthrough
+                    default:
+                        break loop;
+                }
             }
             context.variables.reset(varName);
             return result;

--- a/src/tags/function.js
+++ b/src/tags/function.js
@@ -7,6 +7,7 @@
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
 
+const { FlowState } = require('../structures/bbtag/FlowControl');
 const Builder = require('../structures/TagBuilder'),
     argsTag = require('./args');
 
@@ -24,7 +25,7 @@ module.exports =
         .withAlias('func')
         .withArgs(a => [a.require('name'), a.require('code')])
         .withDesc('Defines a function called `name`. Functions are called in the same way as subtags, however they are prefixed with `func.`. ' +
-            'While inside the `code` block of a function, you may use the `params`, `paramsarray` and `paramslength` subtags to access the values ' +
+            'While inside the `code` block of a function, you may use the `functionreturn`, `functionyield`, `params`, `paramsarray` and `paramslength` subtags to access the values ' +
             'passed to the function. These function identically to their `args` counterparts. ' +
             '\n\nPlease note that there is a recursion limit of 200 which is also shared by `{exec}`, `{execcc}` and `{inject}`.')
         .withExample(
@@ -41,23 +42,35 @@ module.exports =
             if (!name.startsWith('func.'))
                 name = 'func.' + name;
 
-            context.override(name, (async function (subtag, context) {
-                if (context.state.stackSize >= 200) {
-                    context.state.return = -1;
-                    return Builder.util.error(subtag, context, 'Terminated recursive tag after ' + context.state.stackSize + ' execs.');
-                }
-
+            context.override(name, (async function (subtag, /** @type {import('../structures/bbtag/Context')} */context) {
                 args = await Promise.all(subtag.children.slice(1).map(arg => this.executeArg(subtag, arg, context)));
+                const childContext = context.makeChild();
                 let overrides = [];
-                overrides.push(context.override('params', parameters.call(this, args)));
-                overrides.push(context.override('paramsarray', () => JSON.stringify(args)));
-                overrides.push(context.override('paramslength', () => args.length));
+                let funcResult = null;
+                overrides.push(childContext.override('params', parameters.call(this, args)));
+                overrides.push(childContext.override('paramsarray', () => JSON.stringify(args)));
+                overrides.push(childContext.override('paramslength', () => args.length));
+                overrides.push(childContext.override(['functionreturn', 'funcreturn'], async (subtag, ctx) => {
+                    if (subtag.children.length >= 1)
+                        funcResult = await this.executeArg(subtag, subtag.children[1], context);
+                    ctx.state.flowState = FlowState.KILL_FUNC;
+                }));
+                overrides.push(childContext.override(['functionyield', 'funcyield'], async (subtag, ctx) => {
+                    if (funcResult === null)
+                        funcResult = '';
+                    if (subtag.children.length >= 1)
+                        funcResult += await this.executeArg(subtag, subtag.children[1], context);
+                }));
 
-                context.state.stackSize++;
                 try {
-                    return await this.executeArg(subtag, code, context);
+                    funcResult = null;
+                    const result = await this.executeArg(subtag, code, childContext);
+                    if (childContext.state.flowState === FlowState.KILL_FUNC)
+                        childContext.state.flowState = FlowState.NORMAL;
+                    if (funcResult !== null)
+                        return funcResult;
+                    return result;
                 } finally {
-                    context.state.stackSize--;
                     overrides.forEach(override => override.revert());
                 }
             }).bind(this));

--- a/src/tags/return.js
+++ b/src/tags/return.js
@@ -7,20 +7,28 @@
  * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
  */
 
+const { FlowState } = require('../structures/bbtag/FlowControl');
 const Builder = require('../structures/TagBuilder');
 
 module.exports =
     Builder.AutoTag('return')
-        .withArgs(a => a.optional('force'))
+        .withArgs(a => [a.optional('force'), a.optional('content')])
         .withDesc('Stops execution of the tag and returns what has been parsed. ' +
+            'If `content` is given, then that will be used as the result of the current tag rather than the normal result. ' +
             'If `force` is `true` then it will also return from any tags calling this tag. ' +
             '`force` defaults to `true`')
         .withExample(
             'This will display. {return} This will not.',
             'This will display.'
         )
-        .whenArgs('0-1', async function (subtag, context, args) {
-            context.state.return = bu.parseBoolean(args[0], true) ? -1 : 1;
+        .whenArgs('0-2', async function (subtag, context, args) {
+            if (bu.parseBoolean(args[0], true)) {
+                context.state.flowState = FlowState.KILL_ALL;
+                context.state.tagResults[0] = args[1];
+            } else {
+                context.state.flowState = FlowState.KILL_TAG;
+                context.state.tagResults[context.state.tagResults.length - 1] = args[1];
+            }
         })
         .whenDefault(Builder.errors.tooManyArguments)
         .build();

--- a/src/tags/yield.js
+++ b/src/tags/yield.js
@@ -1,0 +1,28 @@
+/*
+ * @Author: stupid cat
+ * @Date: 2017-05-07 18:54:23
+ * @Last Modified by: stupid cat
+ * @Last Modified time: 2017-05-07 18:54:23
+ *
+ * This project uses the AGPLv3 license. Please read the license file before using/adapting any of the code.
+ */
+
+const { FlowState } = require('../structures/bbtag/FlowControl');
+const Builder = require('../structures/TagBuilder');
+
+module.exports =
+    Builder.AutoTag('yield')
+        .withArgs(a => [a.optional('content')])
+        .withDesc('Appends to the output of the current tag without returning anything. ' +
+            'If you are going to use this in a tag, make sure at least 1 `{yield}` is guaranteed to execute otherwise you might get ' +
+            'the normal output rather than blank like you would expect')
+        .withExample(
+            '{yield;Hi!}\nThis is invisible\n{yield;{space}My name is blargbot!}',
+            'Hi! My name is blargbot!'
+        )
+        .whenArgs('0-1', async function (subtag, context, args) {
+            const i = context.state.tagResults.length - 1;
+            context.state.tagResults[i] = (context.state.tagResults[i] || '') + (args[0] || '');
+        })
+        .whenDefault(Builder.errors.tooManyArguments)
+        .build();


### PR DESCRIPTION
Added a second parameter to {return} to set the result of the current tag/command
Added a {yield} subtag to build up the result of the current tag/command
Added a {break} subtag to break loops
Added a {continue} subtag to skip to the next loop in the looping subtags
Added a {functionreturn} subtag to set the result of a func
Added a {functionyield} subtag to build up the result of the current function