### PR TITLE
Add allowed mentions to webhook payload

### DIFF
--- a/src/structures/bbtag/Context.js
+++ b/src/structures/bbtag/Context.js
@@ -245,24 +245,28 @@ class Context {
         return await this.state.outputMessage;
     }
 
-    async sendOutputForced(text, files) {
+    async getAllowedMentions() {
         let disableEveryone = true;
         if (this.isCC) {
-            let s = await r.table('guild').get(this.msg.guild.id);
+            let s = await bu.getGuild(this.msg.guild.id);
             disableEveryone = s.settings.disableeveryone === true || !this.state.allowedMentions.everybody;
 
             console.log('Allowed mentions:', this.state.allowedMentions, disableEveryone);
         }
+        return {
+            everyone: !disableEveryone,
+            roles: !!this.isCC ? this.state.allowedMentions.roles : false,
+            users: !!this.isCC ? this.state.allowedMentions.users : false
+        };
+    }
+
+    async sendOutputForced(text, files) {
         let response = await bu.send(this.msg,
             {
                 content: this.outputModify(this, text),
                 embed: this.state.embed,
                 nsfw: this.state.nsfw,
-                allowedMentions: {
-                    everyone: !disableEveryone,
-                    roles: !!this.isCC ? this.state.allowedMentions.roles : false,
-                    users: !!this.isCC ? this.state.allowedMentions.users : false
-                }
+                allowedMentions: await this.getAllowedMentions()
             }, files || this.state.file);
 
         if (response && response.channel) {

--- a/src/tags/send.js
+++ b/src/tags/send.js
@@ -45,20 +45,11 @@ module.exports =
                 }
             }
             try {
-                let disableEveryone = true;
-                if (context.isCC) {
-                    let s = await r.table('guild').get(context.msg.guild.id);
-                    disableEveryone = s.settings.disableeveryone === true || !context.state.allowedMentions.everybody;
-                }
                 let sent = await bu.send(channel.id, {
                     content: message,
                     embed: embed,
                     nsfw: context.state.nsfw,
-                    allowedMentions: {
-                        everyone: !disableEveryone,
-                        roles: !!context.isCC ? context.state.allowedMentions.roles : false,
-                        users: !!context.isCC ? context.state.allowedMentions.users : false
-                    }
+                    allowedMentions: await context.getAllowedMentions()
                 }, file);
 
                 if (!sent) throw new Error('Send unsuccessful');

--- a/src/tags/webhook.js
+++ b/src/tags/webhook.js
@@ -22,13 +22,13 @@ module.exports =
             a.optional('filename')
         ])
         .withDesc('Executes a webhook. The `embed` must be provided in a raw JSON format, properly escaped for BBTag. ' +
-        'A simple escaping utility can be accessed [here](https://rewrite.blargbot.xyz/v1escaper). ' +
-        'You can find an easy tool to test out embeds [here](https://leovoel.github.io/embed-visualizer/). ' +
-        'Please assign your webhook credentials to private variables! Do not leave them in your code. ' +
-        'If `file` starts with `buffer:`, the following text will be parsed as base64 to a raw buffer.')
+            'A simple escaping utility can be accessed [here](https://rewrite.blargbot.xyz/v1escaper). ' +
+            'You can find an easy tool to test out embeds [here](https://leovoel.github.io/embed-visualizer/). ' +
+            'Please assign your webhook credentials to private variables! Do not leave them in your code. ' +
+            'If `file` starts with `buffer:`, the following text will be parsed as base64 to a raw buffer.')
         .withExample(
-        '{webhook;1111111111111111;t.OK-en;Hello!}',
-        'In the webhook channel: Hello!'
+            '{webhook;1111111111111111;t.OK-en;Hello!}',
+            'In the webhook channel: Hello!'
         )
         .whenArgs('0-1', Builder.errors.notEnoughArguments)
         .whenArgs('2-8', async function (subtag, context, args) {
@@ -56,7 +56,8 @@ module.exports =
                     avatarURL: avatar,
                     content: content,
                     embeds: embed ? (Array.isArray(embed) ? embed : [embed]) : [],
-                    file
+                    file,
+                    allowedMentions: await context.getAllowedMentions()
                 });
             }
             catch (err) {


### PR DESCRIPTION
The webhook subtag doesnt respect the allowed mentions list, causing it to never send any mentions. This makes it use the same list as output and send