### PR TITLE
Misc fixes

### DIFF
--- a/src/bbtag/subtags/message/waitmessage.ts
+++ b/src/bbtag/subtags/message/waitmessage.ts
@@ -70,8 +70,11 @@ export class WaitMessageSubtag extends CompiledSubtag {
             if (!userSet.has(message.author.id) || !guard.isGuildMessage(message))
                 return false;
 
-            const result = parse.boolean(await context.withChild({ message }, async context => await context.eval(condition)));
-            return result ?? false; //Feel like it should error if a non-boolean is returned
+            const resultStr = await context.withChild({ message }, async context => await context.eval(condition));
+            const result = parse.boolean(resultStr.trim());
+            if (result === undefined)
+                throw new BBTagRuntimeError('Condition must return \'true\' or \'false\'', `Actually returned ${JSON.stringify(resultStr)}`);
+            return result;
         }, timeout * 1000);
 
         if (result === undefined)

--- a/src/bbtag/subtags/message/waitreaction.ts
+++ b/src/bbtag/subtags/message/waitreaction.ts
@@ -89,12 +89,15 @@ export class WaitReactionSubtag extends CompiledSubtag {
             if (!userSet.has(user.id) || !checkReaction(reaction) || !guard.isGuildMessage(message))
                 return false;
 
-            const result = await context.withScope(scope => {
+            const resultStr = await context.withScope(scope => {
                 scope.reaction = reaction.toString();
                 scope.reactUser = user.id;
                 return context.withChild({ message }, context => context.eval(condition));
             });
-            return parse.boolean(result, false);
+            const result = parse.boolean(resultStr.trim());
+            if (result === undefined)
+                throw new BBTagRuntimeError('Condition must return \'true\' or \'false\'', `Actually returned ${JSON.stringify(resultStr)}`);
+            return result;
         }, timeout * 1000);
 
         if (result === undefined)

--- a/src/bbtag/utils/json.ts
+++ b/src/bbtag/utils/json.ts
@@ -85,8 +85,6 @@ export const json = Object.freeze({
     getPathKeys(path: string | readonly string[]): readonly string[] {
         if (typeof path !== 'string')
             return path;
-        if (path === '')
-            return [];
         return path.split('.');
     },
     parse(value: string): JToken | undefined {

--- a/src/cluster/dcommands/general/define.ts
+++ b/src/cluster/dcommands/general/define.ts
@@ -74,7 +74,7 @@ const wordApiMapping = mapping.object({
         definition: mapping.string,
         partOfSpeech: mapping.string,
         synonyms: mapping.array(mapping.string).optional
-    })),
+    }, { strict: false })),
     frequency: mapping.number,
     pronunciation: mapping.record(mapping.choice(mapping.in(undefined), mapping.string))
-});
+}, { strict: false });

--- a/src/cluster/managers/awaiters/Awaiter.ts
+++ b/src/cluster/managers/awaiters/Awaiter.ts
@@ -23,11 +23,17 @@ export class Awaiter<T> {
     }
 
     public async tryConsume(item: T): Promise<boolean> {
-        if (!await this.check(item))
-            return false;
-        this.pcs.resolve(item);
-        this.cleanup();
-        return true;
+        try {
+            if (!await this.check(item))
+                return false;
+            this.pcs.resolve(item);
+            this.cleanup();
+            return true;
+        } catch (ex: unknown) {
+            this.pcs.reject(ex);
+            this.cleanup();
+            return true;
+        }
     }
 
     public cancel(): void {

--- a/test/bbtag/subtags/message/waitmessage.test.ts
+++ b/test/bbtag/subtags/message/waitmessage.test.ts
@@ -349,23 +349,20 @@ runSubtagTests({
             }
         },
         {
-            code: '{waitmessage;21938762934928374;289374634729826479828;{eval}abc;310}',
-            expected: '`Wait timed out after 300000`',
+            code: '{waitmessage;21938762934928374;289374634729826479828;{eval} abc;310}',
+            expected: '`Condition must return \'true\' or \'false\'`',
             errors: [
                 { start: 53, end: 59, error: new MarkerError('eval', 53) },
-                { start: 53, end: 59, error: new MarkerError('eval', 53) },
-                { start: 0, end: 67, error: new BBTagRuntimeError('Wait timed out after 300000') }
+                { start: 0, end: 68, error: new BBTagRuntimeError('Condition must return \'true\' or \'false\'', 'Actually returned " abc"') }
             ],
             setup(ctx) {
                 ctx.channels.command.id = '9834653278429843564';
                 ctx.message.channel_id = ctx.channels.command.id;
             },
             postSetup(bbctx, ctx) {
-                const acceptedMessage = createFilterableMessage(ctx, bbctx.guild, '3982746234283749322', ctx.channels.command.id, '289374634729826479828');
-                const filterableMessage = createFilterableMessage(ctx, bbctx.guild, '5847658249242834983', ctx.channels.command.id, '289374634729826479828');
-                const rejectedMessage = createRejectedMessage(ctx);
+                const rejectedMessage = createFilterableMessage(ctx, bbctx.guild, '3982746234283749322', ctx.channels.command.id, '289374634729826479828');
                 ctx.util.setup(m => m.awaitMessage(argument.isDeepEqual(['21938762934928374']), anyCondition.value, 300000))
-                    .thenCall(createFakeAwaiterFactory(acceptedMessage.instance, [filterableMessage.instance, rejectedMessage.instance]));
+                    .thenCall(createFakeAwaiterFactory(undefined, [rejectedMessage.instance]));
 
                 const channel = ctx.createMock(TextChannel);
                 channel.setup(m => m.id).thenReturn('21938762934928374');

--- a/test/bbtag/subtags/message/waitreaction.test.ts
+++ b/test/bbtag/subtags/message/waitreaction.test.ts
@@ -436,23 +436,20 @@ runSubtagTests({
             }
         },
         {
-            code: '{waitreaction;328974628744623874;23897462384627348293436;;{eval}abc}',
-            expected: '`Wait timed out after 60000`',
+            code: '{waitreaction;328974628744623874;23897462384627348293436;;{eval} abc}',
+            expected: '`Condition must return \'true\' or \'false\'`',
             errors: [
                 { start: 58, end: 64, error: new MarkerError('eval', 58) },
-                { start: 58, end: 64, error: new MarkerError('eval', 58) },
-                { start: 0, end: 68, error: new BBTagRuntimeError('Wait timed out after 60000') }
+                { start: 0, end: 69, error: new BBTagRuntimeError('Condition must return \'true\' or \'false\'', 'Actually returned " abc"') }
             ],
             setup(ctx) {
                 ctx.channels.command.id = '2384792374232398472';
                 ctx.message.channel_id = ctx.channels.command.id;
             },
             postSetup(bbctx, ctx) {
-                const acceptedReaction = createFilterableReaction(ctx, bbctx.guild, '🤔', '328974628744623874', '2384792374232398472', '23897462384627348293436');
-                const filteredReaction = createFilterableReaction(ctx, bbctx.guild, '❌', '328974628744623874', '2384792374232398472', '23897462384627348293436');
-                const rejectedReaction = createRejectedReaction(ctx, '🤔', '32409764893267492832423');
+                const rejectedReaction = createFilterableReaction(ctx, bbctx.guild, '🤔', '328974628744623874', '2384792374232398472', '23897462384627348293436');
                 ctx.util.setup(m => m.awaitReaction(argument.isDeepEqual(['328974628744623874']), anyCondition.value, 60000))
-                    .thenCall(createFakeAwaiterFactory(acceptedReaction, [rejectedReaction, filteredReaction]));
+                    .thenCall(createFakeAwaiterFactory(undefined, [rejectedReaction]));
 
                 const member = ctx.createMock(Member);
                 const user = ctx.createMock(User);


### PR DESCRIPTION
- Regression fix for {waitreact} and {waitmessage}.
  - if the condition doesnt return `true` or `false`, an error should be thrown. [Old code](https://github.com/blargbot/blargbot/blob/1189d139610f51e9fec1c19871f821fc166d238d/src/tags/waitmessage.js#L146-L150)

- Regression fix for {jget;~var;}
  - In js blarg this used to get the `""` property (empty key). 
  ![image](https://user-images.githubusercontent.com/7736591/174386264-cb867cd5-ff22-4583-bc25-388a1da61b6f.png)

- Fix for define command not working
  - Api response structure added new props but the parser was strict so rejected the payload