### PR TITLE
Dont persist bbcontext data through timer

### DIFF
--- a/src/bbtag/BBTagContext.ts
+++ b/src/bbtag/BBTagContext.ts
@@ -477,7 +477,6 @@ export class BBTagContext implements BBTagContextOptions {
             tagName: obj.tagName,
             authorId: obj.author,
             authorizerId: obj.authorizer,
-            data: obj.data,
             limit: limit,
             tagVars: obj.tagVars
         });
@@ -492,7 +491,6 @@ export class BBTagContext implements BBTagContextOptions {
     }
 
     public serialize(): SerializedBBTagContext {
-        const newState = { ...this.data, cache: undefined, overrides: undefined };
         const newScope = { ...this.scopes.local };
         return {
             msg: {
@@ -505,7 +503,6 @@ export class BBTagContext implements BBTagContextOptions {
                 embeds: this.message.embeds
             },
             isCC: this.isCC,
-            data: newState,
             scope: newScope,
             inputRaw: this.inputRaw,
             flags: this.flags,

--- a/src/bbtag/BBTagContext.ts
+++ b/src/bbtag/BBTagContext.ts
@@ -475,6 +475,7 @@ export class BBTagContext implements BBTagContextOptions {
             flags: obj.flags,
             rootTagName: obj.rootTagName,
             tagName: obj.tagName,
+            data: obj.data,
             authorId: obj.author,
             authorizerId: obj.authorizer,
             limit: limit,
@@ -505,6 +506,12 @@ export class BBTagContext implements BBTagContextOptions {
             isCC: this.isCC,
             scope: newScope,
             inputRaw: this.inputRaw,
+            data: {
+                allowedMentions: this.data.allowedMentions,
+                ownedMsgs: this.data.ownedMsgs,
+                query: this.data.query,
+                stackSize: this.data.stackSize
+            },
             flags: this.flags,
             rootTagName: this.rootTagName,
             tagName: this.tagName,

--- a/src/bbtag/types.ts
+++ b/src/bbtag/types.ts
@@ -57,7 +57,6 @@ export interface SerializedBBTagContext {
         embeds: Embed[];
     };
     isCC: boolean;
-    data: Omit<BBTagContextState, 'cache'>;
     scope: BBTagRuntimeScope;
     inputRaw: string;
     flags: readonly FlagDefinition[];

--- a/src/bbtag/types.ts
+++ b/src/bbtag/types.ts
@@ -60,6 +60,7 @@ export interface SerializedBBTagContext {
     scope: BBTagRuntimeScope;
     inputRaw: string;
     flags: readonly FlagDefinition[];
+    data: Pick<BBTagContextState, 'query' | 'ownedMsgs' | 'stackSize' | 'allowedMentions'>;
     tagName: string;
     rootTagName: string;
     author: string | undefined;


### PR DESCRIPTION
Embeds and files set before starting a timer would be sent again by the timer
- Old blarg would ignore some of the `data` (previously `state`) of the context in a timer. [Evidence](https://github.com/blargbot/blargbot/blob/1189d139610f51e9fec1c19871f821fc166d238d/src/dcommands/tag.js#L829-L913)