### PR TITLE
Fix UTC+0 offset not being applied in {userboostdate}

### DIFF
--- a/src/bbtag/subtags/user/userboostdate.ts
+++ b/src/bbtag/subtags/user/userboostdate.ts
@@ -6,7 +6,7 @@ import { CompiledSubtag } from '../../compilation';
 import { BBTagRuntimeError, UserNotFoundError } from '../../errors';
 import { SubtagType } from '../../utils';
 
-export class UserBoostDataSubtag extends CompiledSubtag {
+export class UserBoostDateSubtag extends CompiledSubtag {
     public constructor() {
         super({
             name: 'userboostdate',
@@ -27,8 +27,8 @@ export class UserBoostDataSubtag extends CompiledSubtag {
                     parameters: ['format:YYYY-MM-DDTHH:mm:ssZ', 'user', 'quiet?'],
                     description: 'Returns the date that `user` started boosting the current guild using `format` for the output, in UTC+0. ' +
                         'If `quiet` is specified, if `user` can\'t be found it will simply return nothing.',
-                    exampleCode: '{if;{isuserboosting;stupid cat};stupid cat is boosting!; no boosting here :(}',
-                    exampleOut: 'stupid cat is boosting!',
+                    exampleCode: 'Stupid cat started boosting this guild on {userboostdate;YYYY/MM/DD HH:mm:ss;stupid cat}',
+                    exampleOut: 'Stupid cat started boosting this guild on 2020/02/27 00:00:00',
                     returns: 'string',
                     execute: (context, [format, user, quiet]) => this.findUserBoostDate(context, format.value, user.value, quiet.value !== '')
                 }
@@ -52,6 +52,6 @@ export class UserBoostDataSubtag extends CompiledSubtag {
         if (typeof user.premiumSince !== 'number')
             throw new BBTagRuntimeError('User not boosting');
 
-        return moment(user.premiumSince).format(format);
+        return moment(user.premiumSince).utcOffset(0).format(format);
     }
 }

--- a/test/bbtag/subtags/user/userboostdate.test.ts
+++ b/test/bbtag/subtags/user/userboostdate.test.ts
@@ -1,11 +1,11 @@
 import { BBTagRuntimeError } from '@blargbot/bbtag/errors';
-import { UserBoostDataSubtag } from '@blargbot/bbtag/subtags/user/userboostdate';
+import { UserBoostDateSubtag } from '@blargbot/bbtag/subtags/user/userboostdate';
 
 import { runSubtagTests } from '../SubtagTestSuite';
 import { createGetUserPropTestCases } from './_getUserPropTest';
 
 runSubtagTests({
-    subtag: new UserBoostDataSubtag(),
+    subtag: new UserBoostDateSubtag(),
     argCountBounds: { min: 0, max: 3 },
     cases: [
         {


### PR DESCRIPTION
This offsets the moment to utc 0, just like it was on blarg-js.

This also fixes wrong example docs for `{userboosdate;<format>;<user>;[quiet]}` and fixes a classname typo