### PR TITLE
Autoresponse only uses captures if > 0

### DIFF
--- a/src/cluster/managers/AutoresponseManager.ts
+++ b/src/cluster/managers/AutoresponseManager.ts
@@ -106,7 +106,7 @@ ${codeBlock(code, 'js')}`
             limit: id === 'everything' ? 'everythingAutoResponseLimit' : 'generalAutoResponseLimit',
             authorId: tag.author ?? undefined,
             authorizerId: tag.authorizer ?? undefined,
-            inputRaw: humanize.smartSplit.inverse(args),
+            inputRaw: args.length === 1 ? msg.content : humanize.smartSplit.inverse(args),
             isCC: true,
             rootTagName: `_autoresponse_${id}`,
             silent: id === 'everything'

--- a/src/core/utils/guard/matchMessageFilter.ts
+++ b/src/core/utils/guard/matchMessageFilter.ts
@@ -8,13 +8,10 @@ export function matchMessageFilter(filter: MessageFilter, message: KnownMessage)
     let content = message.content;
     if (filter.decancer === true)
         content = humanize.decancer(content);
-    if (filter.regex) {
-        const result = matchRegexSafe(filter.term, content);
-        if (result?.length === 1)
-            return [content];
-        return result;
-    }
+    if (filter.regex)
+        return matchRegexSafe(filter.term, content);
+
     if (content.toLowerCase().includes(filter.term.toLowerCase()))
-        return [content];
+        return [filter.term];
     return undefined;
 }


### PR DESCRIPTION
Fixes an [autoresponse Issue](https://discord.com/channels/194232473931087872/988044656665325600) where argslength is always 1

[Duplicate report](https://discord.com/channels/194232473931087872/988457883626795009)