### PR TITLE
Derive TTL from channelid column

### DIFF
--- a/src/database/stores/CassandraDbDumpStore.ts
+++ b/src/database/stores/CassandraDbDumpStore.ts
@@ -28,7 +28,7 @@ export class CassandraDbDumpStore implements DumpStore {
     }
 
     public async get(id: string): Promise<Dump | undefined> {
-        const dump = await this.cassandra.execute('SELECT id, content, embeds, channelid, TTL(content) as expiry FROM message_outputs WHERE id = :id', { id }, { prepare: true });
+        const dump = await this.cassandra.execute('SELECT id, content, embeds, channelid, TTL(channelid) as expiry FROM message_outputs WHERE id = :id', { id }, { prepare: true });
         const mapped = mapDump(dump.rows[0]);
         return mapped.valid ? mapped.value : undefined;
     }


### PR DESCRIPTION
Dumps are now only generated when the embed is too long. This means the content might be null, meaning the page cant be viewed as the expiry column fails to map
![image](https://user-images.githubusercontent.com/7736591/175822226-dbc76edd-7ea7-419d-86fb-f51f1185e101.png)
https://blargbot.xyz/dumps/990637014720297239