### PR TITLE
Fix flags in exec(cc)

### DIFF
--- a/src/core/utils/parse/flags.ts
+++ b/src/core/utils/parse/flags.ts
@@ -11,7 +11,10 @@ export function parseFlags(definitions: Iterable<FlagDefinition>, text: string, 
     const flagKeys = new Set<string>(defArr.map(d => d.flag));
 
     for (const { start, end, value } of humanize.smartSplitRanges(text)) {
-        if (!/^--?[a-z0-9]|^--$/i.test(value) || text[start] !== value[0]) {
+        const offset = text[start] === '"' && text[end - 1] === '"' ? 1 : 0;
+        if (!/^--?[a-z0-9]|^--$/i.test(value)) {
+            currentGroup.push({ start, end, value });
+        } else if (text[start] !== '"' && text[start] !== value[0]) {
             currentGroup.push({ start, end, value });
         } else if (value === '--') {
             if (currentFlag !== '_') {
@@ -48,7 +51,7 @@ export function parseFlags(definitions: Iterable<FlagDefinition>, text: string, 
             if (!flagMatched)
                 currentGroup.push({ start, end, value });
             else if (flagStr.length < value.length)
-                currentGroup.push({ start: start + flagStr.length + 1, end, value: value.slice(flagStr.length + 1) });
+                currentGroup.push({ start: start + offset + flagStr.length + 1, end: end - offset, value: value.slice(flagStr.length + 1) });
         }
     }
 

--- a/test/bbtag/subtags/bot/exec.test.ts
+++ b/test/bbtag/subtags/bot/exec.test.ts
@@ -170,6 +170,150 @@ runSubtagTests({
                 expect(ctx.data.stackSize).to.equal(200);
                 expect(ctx.data.state).to.equal(BBTagRuntimeState.ABORT);
             }
+        },
+        {
+            code: '{exec;otherSubtag;arg1;arg2;-f flag value}',
+            expected: 'Success!',
+            subtags: [new AssertSubtag((ctx) => {
+                expect(ctx.parent).to.not.be.undefined;
+                expect(ctx.tagName).to.equal('otherSubtag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(7);
+                expect(ctx.inputRaw).to.equal('arg1 arg2 "-f flag value"');
+                expect(ctx.input).to.deep.equal(['arg1', 'arg2', '-f flag value']);
+                expect(ctx.flaggedInput.f?.merge().raw).to.equal('flag value');
+                expect(ctx.flaggedInput._.merge().raw).to.equal('arg1 arg2');
+                expect(ctx.data.stackSize).to.equal(101);
+                expect(ctx.scopes.local).to.not.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.not.equal(ctx.scopes.root);
+                return 'Success!';
+            })],
+            errors: [
+                { start: 8, end: 14, error: new MarkerError('eval', 8) }
+            ],
+            setup(ctx) {
+                ctx.options.cooldown = 4;
+                ctx.options.tagName = 'test tag';
+                ctx.options.rootTagName = 'test tag';
+                ctx.options.inputRaw = 'This is some input text';
+                ctx.options.data = { stackSize: 100 };
+                ctx.tags['otherSubtag'] = {
+                    author: '212097368371683623',
+                    content: '{assert}{eval}',
+                    name: 'otherSubtag',
+                    lastmodified: new Date(),
+                    uses: 0,
+                    cooldown: 7
+                };
+            },
+            assert(ctx) {
+                expect(ctx.parent).to.be.undefined;
+                expect(ctx.tagName).to.equal('test tag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(4);
+                expect(ctx.inputRaw).to.equal('This is some input text');
+                expect(ctx.flaggedInput.f?.merge().raw).to.be.undefined;
+                expect(ctx.flaggedInput._.merge().raw).to.equal('This is some input text');
+                expect(ctx.data.stackSize).to.equal(100);
+                expect(ctx.scopes.local).to.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.equal(ctx.scopes.root);
+            }
+        },
+        {
+            code: '{exec;otherSubtag;arg1 arg2 -f flag value}',
+            expected: 'Success!',
+            subtags: [new AssertSubtag((ctx) => {
+                expect(ctx.parent).to.not.be.undefined;
+                expect(ctx.tagName).to.equal('otherSubtag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(7);
+                expect(ctx.inputRaw).to.equal('arg1 arg2 -f flag value');
+                expect(ctx.input).to.deep.equal(['arg1', 'arg2', '-f', 'flag', 'value']);
+                expect(ctx.flaggedInput.f?.merge().raw).to.equal('flag value');
+                expect(ctx.flaggedInput._.merge().raw).to.equal('arg1 arg2');
+                expect(ctx.data.stackSize).to.equal(101);
+                expect(ctx.scopes.local).to.not.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.not.equal(ctx.scopes.root);
+                return 'Success!';
+            })],
+            errors: [
+                { start: 8, end: 14, error: new MarkerError('eval', 8) }
+            ],
+            setup(ctx) {
+                ctx.options.cooldown = 4;
+                ctx.options.tagName = 'test tag';
+                ctx.options.rootTagName = 'test tag';
+                ctx.options.inputRaw = 'This is some input text';
+                ctx.options.data = { stackSize: 100 };
+                ctx.tags['otherSubtag'] = {
+                    author: '212097368371683623',
+                    content: '{assert}{eval}',
+                    name: 'otherSubtag',
+                    lastmodified: new Date(),
+                    uses: 0,
+                    cooldown: 7
+                };
+            },
+            assert(ctx) {
+                expect(ctx.parent).to.be.undefined;
+                expect(ctx.tagName).to.equal('test tag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(4);
+                expect(ctx.inputRaw).to.equal('This is some input text');
+                expect(ctx.flaggedInput.f?.merge().raw).to.be.undefined;
+                expect(ctx.flaggedInput._.merge().raw).to.equal('This is some input text');
+                expect(ctx.data.stackSize).to.equal(100);
+                expect(ctx.scopes.local).to.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.equal(ctx.scopes.root);
+            }
+        },
+        {
+            code: '{exec;otherSubtag;arg1 arg2 \\-f flag value}',
+            expected: 'Success!',
+            subtags: [new AssertSubtag((ctx) => {
+                expect(ctx.parent).to.not.be.undefined;
+                expect(ctx.tagName).to.equal('otherSubtag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(7);
+                expect(ctx.inputRaw).to.equal('arg1 arg2 \\-f flag value');
+                expect(ctx.input).to.deep.equal(['arg1', 'arg2', '-f', 'flag', 'value']);
+                expect(ctx.flaggedInput.f?.merge().raw).to.be.undefined;
+                expect(ctx.flaggedInput._.merge().raw).to.equal('arg1 arg2 \\-f flag value');
+                expect(ctx.data.stackSize).to.equal(101);
+                expect(ctx.scopes.local).to.not.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.not.equal(ctx.scopes.root);
+                return 'Success!';
+            })],
+            errors: [
+                { start: 8, end: 14, error: new MarkerError('eval', 8) }
+            ],
+            setup(ctx) {
+                ctx.options.cooldown = 4;
+                ctx.options.tagName = 'test tag';
+                ctx.options.rootTagName = 'test tag';
+                ctx.options.inputRaw = 'This is some input text';
+                ctx.options.data = { stackSize: 100 };
+                ctx.tags['otherSubtag'] = {
+                    author: '212097368371683623',
+                    content: '{assert}{eval}',
+                    name: 'otherSubtag',
+                    lastmodified: new Date(),
+                    uses: 0,
+                    cooldown: 7
+                };
+            },
+            assert(ctx) {
+                expect(ctx.parent).to.be.undefined;
+                expect(ctx.tagName).to.equal('test tag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(4);
+                expect(ctx.inputRaw).to.equal('This is some input text');
+                expect(ctx.flaggedInput.f?.merge().raw).to.be.undefined;
+                expect(ctx.flaggedInput._.merge().raw).to.equal('This is some input text');
+                expect(ctx.data.stackSize).to.equal(100);
+                expect(ctx.scopes.local).to.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.equal(ctx.scopes.root);
+            }
         }
     ]
 });

--- a/test/bbtag/subtags/bot/execcc.test.ts
+++ b/test/bbtag/subtags/bot/execcc.test.ts
@@ -173,6 +173,141 @@ runSubtagTests({
                 expect(ctx.data.stackSize).to.equal(200);
                 expect(ctx.data.state).to.equal(BBTagRuntimeState.ABORT);
             }
+        },
+        {
+            code: '{execcc;otherSubtag;arg1;arg2;-f flag value}',
+            expected: 'Success!',
+            subtags: [new AssertSubtag((ctx) => {
+                expect(ctx.parent).to.not.be.undefined;
+                expect(ctx.tagName).to.equal('othersubtag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(7);
+                expect(ctx.inputRaw).to.equal('arg1 arg2 "-f flag value"');
+                expect(ctx.input).to.deep.equal(['arg1', 'arg2', '-f flag value']);
+                expect(ctx.flaggedInput.f?.merge().raw).to.equal('flag value');
+                expect(ctx.flaggedInput._.merge().raw).to.equal('arg1 arg2');
+                expect(ctx.data.stackSize).to.equal(101);
+                expect(ctx.scopes.local).to.not.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.not.equal(ctx.scopes.root);
+                return 'Success!';
+            })],
+            errors: [
+                { start: 8, end: 14, error: new MarkerError('eval', 8) }
+            ],
+            setup(ctx) {
+                ctx.options.cooldown = 4;
+                ctx.options.tagName = 'test tag';
+                ctx.options.rootTagName = 'test tag';
+                ctx.options.inputRaw = 'This is some input text';
+                ctx.options.data = { stackSize: 100 };
+                ctx.ccommands['othersubtag'] = {
+                    author: '212097368371683623',
+                    content: '{assert}{eval}',
+                    cooldown: 7
+                };
+            },
+            assert(ctx) {
+                expect(ctx.parent).to.be.undefined;
+                expect(ctx.tagName).to.equal('test tag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(4);
+                expect(ctx.inputRaw).to.equal('This is some input text');
+                expect(ctx.flaggedInput.f?.merge().raw).to.be.undefined;
+                expect(ctx.flaggedInput._.merge().raw).to.equal('This is some input text');
+                expect(ctx.data.stackSize).to.equal(100);
+                expect(ctx.scopes.local).to.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.equal(ctx.scopes.root);
+            }
+        },
+        {
+            code: '{execcc;otherSubtag;arg1 arg2 -f flag value}',
+            expected: 'Success!',
+            subtags: [new AssertSubtag((ctx) => {
+                expect(ctx.parent).to.not.be.undefined;
+                expect(ctx.tagName).to.equal('othersubtag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(7);
+                expect(ctx.inputRaw).to.equal('arg1 arg2 -f flag value');
+                expect(ctx.input).to.deep.equal(['arg1', 'arg2', '-f', 'flag', 'value']);
+                expect(ctx.flaggedInput.f?.merge().raw).to.equal('flag value');
+                expect(ctx.flaggedInput._.merge().raw).to.equal('arg1 arg2');
+                expect(ctx.data.stackSize).to.equal(101);
+                expect(ctx.scopes.local).to.not.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.not.equal(ctx.scopes.root);
+                return 'Success!';
+            })],
+            errors: [
+                { start: 8, end: 14, error: new MarkerError('eval', 8) }
+            ],
+            setup(ctx) {
+                ctx.options.cooldown = 4;
+                ctx.options.tagName = 'test tag';
+                ctx.options.rootTagName = 'test tag';
+                ctx.options.inputRaw = 'This is some input text';
+                ctx.options.data = { stackSize: 100 };
+                ctx.ccommands['othersubtag'] = {
+                    author: '212097368371683623',
+                    content: '{assert}{eval}',
+                    cooldown: 7
+                };
+            },
+            assert(ctx) {
+                expect(ctx.parent).to.be.undefined;
+                expect(ctx.tagName).to.equal('test tag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(4);
+                expect(ctx.inputRaw).to.equal('This is some input text');
+                expect(ctx.flaggedInput.f?.merge().raw).to.be.undefined;
+                expect(ctx.flaggedInput._.merge().raw).to.equal('This is some input text');
+                expect(ctx.data.stackSize).to.equal(100);
+                expect(ctx.scopes.local).to.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.equal(ctx.scopes.root);
+            }
+        },
+        {
+            code: '{execcc;otherSubtag;arg1 arg2 \\-f flag value}',
+            expected: 'Success!',
+            subtags: [new AssertSubtag((ctx) => {
+                expect(ctx.parent).to.not.be.undefined;
+                expect(ctx.tagName).to.equal('othersubtag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(7);
+                expect(ctx.inputRaw).to.equal('arg1 arg2 \\-f flag value');
+                expect(ctx.input).to.deep.equal(['arg1', 'arg2', '-f', 'flag', 'value']);
+                expect(ctx.flaggedInput.f?.merge().raw).to.be.undefined;
+                expect(ctx.flaggedInput._.merge().raw).to.equal('arg1 arg2 \\-f flag value');
+                expect(ctx.data.stackSize).to.equal(101);
+                expect(ctx.scopes.local).to.not.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.not.equal(ctx.scopes.root);
+                return 'Success!';
+            })],
+            errors: [
+                { start: 8, end: 14, error: new MarkerError('eval', 8) }
+            ],
+            setup(ctx) {
+                ctx.options.cooldown = 4;
+                ctx.options.tagName = 'test tag';
+                ctx.options.rootTagName = 'test tag';
+                ctx.options.inputRaw = 'This is some input text';
+                ctx.options.data = { stackSize: 100 };
+                ctx.ccommands['othersubtag'] = {
+                    author: '212097368371683623',
+                    content: '{assert}{eval}',
+                    cooldown: 7
+                };
+            },
+            assert(ctx) {
+                expect(ctx.parent).to.be.undefined;
+                expect(ctx.tagName).to.equal('test tag');
+                expect(ctx.rootTagName).to.equal('test tag');
+                expect(ctx.cooldown).to.equal(4);
+                expect(ctx.inputRaw).to.equal('This is some input text');
+                expect(ctx.flaggedInput.f?.merge().raw).to.be.undefined;
+                expect(ctx.flaggedInput._.merge().raw).to.equal('This is some input text');
+                expect(ctx.data.stackSize).to.equal(100);
+                expect(ctx.scopes.local).to.equal(ctx.scopes.root);
+                expect(ctx.scopes.tag).to.equal(ctx.scopes.root);
+            }
         }
     ]
 });


### PR DESCRIPTION
Fixes [flags broken inside of '{exec}' when arguments passed before them](https://discord.com/channels/194232473931087872/997769937865150534)