### PR TITLE
Fix incorrect message from unresponsive cluster & reduce double respawn risk

### DIFF
--- a/src/core/serviceTypes/WorkerPoolEventService.ts
+++ b/src/core/serviceTypes/WorkerPoolEventService.ts
@@ -24,22 +24,22 @@ export abstract class WorkerPoolEventService<TWorker extends WorkerConnection<IP
     }
 
     public start(): void {
-        this.workers.on('spawningworker', this.#attach);
-        this.workers.on('killingworker', this.#detach);
+        this.workers.on('spawningWorker', this.#attach);
+        this.workers.on('killingWorker', this.#detach);
     }
 
     public stop(): void {
-        this.workers.off('spawningworker', this.#attach);
-        this.workers.off('killingworker', this.#detach);
+        this.workers.off('spawningWorker', this.#attach);
+        this.workers.off('killingWorker', this.#detach);
     }
 
-    private attach(worker: TWorker): void {
+    protected attach(worker: TWorker): void {
         const handler: ProcessMessageHandler = message => this.#execute({ ...message, worker });
         this.#handlers.set(worker, handler);
         worker.on(this.contract, handler);
     }
 
-    private detach(worker: TWorker): void {
+    protected detach(worker: TWorker): void {
         const handler = this.#handlers.get(worker);
         if (handler === undefined)
             return;

--- a/src/master/events/cluster/clusterStats.ts
+++ b/src/master/events/cluster/clusterStats.ts
@@ -6,14 +6,19 @@ import { Master } from '@blargbot/master';
 
 export class ClusterClusterStatsHandler extends WorkerPoolEventService<ClusterConnection, 'clusterStats'> {
     public constructor(public readonly master: Master) {
-        super(master.clusters, 'clusterStats', ({ worker, data }) => this.updateStats(worker.id, data));
+        super(master.clusters, 'clusterStats', ({ worker, data }) => this.updateStats(worker, data));
     }
 
-    protected updateStats(workerId: number, stats: ClusterStats): void {
-        this.master.clusterStats.set(workerId, stats);
+    protected updateStats(cluster: ClusterConnection, stats: ClusterStats): void {
+        this.master.clusterStats.set(cluster, stats);
         metrics.shardStatus.reset();
         for (const shard of stats.shards) {
             metrics.shardStatus.labels(shard.status).inc();
         }
+    }
+
+    protected attach(worker: ClusterConnection): void {
+        this.master.clusterStats.set(worker, undefined);
+        super.attach(worker);
     }
 }

--- a/src/master/managers/ClusterStatsManager.ts
+++ b/src/master/managers/ClusterStatsManager.ts
@@ -1,27 +1,38 @@
 import { ApiConnection } from '@blargbot/api';
+import { ClusterConnection } from '@blargbot/cluster';
 import { ClusterStats } from '@blargbot/cluster/types';
 import { WorkerPool } from '@blargbot/core/worker';
 
 export class ClusterStatsManager {
-    private readonly statsMap: Record<number, ClusterStats | undefined>;
+    readonly #statsMap: WeakMap<ClusterConnection, ClusterStats>;
+    readonly #activeClusters: Map<number, ClusterConnection>;
 
     public constructor(private readonly apis: WorkerPool<ApiConnection>) {
-        this.statsMap = {};
+        this.#statsMap = new Map();
+        this.#activeClusters = new Map();
     }
 
-    public set(clusterId: number, stats: ClusterStats | undefined): void {
+    public set(cluster: ClusterConnection, stats: ClusterStats | undefined): void {
         if (stats === undefined)
-            delete this.statsMap[clusterId];
+            this.#statsMap.delete(cluster);
         else
-            this.statsMap[clusterId] = stats;
-        this.apis.forEach((_, api) => api?.send('clusterStats', this.statsMap));
+            this.#statsMap.set(cluster, stats);
+
+        const current = this.#activeClusters.get(cluster.id);
+        if (current?.created.isAfter(cluster.created) === true)
+            return;
+
+        this.#activeClusters.set(cluster.id, cluster);
+        this.apis.forEach((_, api) => api?.send('clusterStats', this.getAll()));
     }
 
-    public get(clusterId: number): ClusterStats | undefined {
-        return this.statsMap[clusterId];
+    public get(cluster: ClusterConnection): ClusterStats | undefined {
+        return this.#statsMap.get(cluster);
     }
 
     public getAll(): Record<number, ClusterStats | undefined> {
-        return this.statsMap;
+        return Object.fromEntries(
+            [...this.#activeClusters.values()].map(cluster => [cluster.id, this.get(cluster)] as const)
+        );
     }
 }


### PR DESCRIPTION
Improves the logging for when a cluster dies, and reduces how often a double respawn will happen.

This is a change to the master process, so will need a `b!respawn kill` to deploy