### PR TITLE
Fix timeout modlog and restrictions

### DIFF
--- a/src/bbtag/limits/CustomCommandLimit.ts
+++ b/src/bbtag/limits/CustomCommandLimit.ts
@@ -14,6 +14,7 @@ export class CustomCommandLimit extends GlobalLimit {
             .addRules('unban', staffOnlyRule)
             .addRules('guildbans', staffOnlyRule)
             .addRules('kick', staffOnlyRule)
+            .addRules('timeout', staffOnlyRule)
             .addRules('modlog', staffOnlyRule)
             .addRules('pardon', staffOnlyRule)
             .addRules('warn', staffOnlyRule)

--- a/src/bbtag/limits/EverythingAutoResponseLimit.ts
+++ b/src/bbtag/limits/EverythingAutoResponseLimit.ts
@@ -12,6 +12,7 @@ export class EverythingAutoResponseLimit extends GlobalLimit {
             .addRules('unban', staffOnlyRule)
             .addRules('guildbans', staffOnlyRule)
             .addRules('kick', staffOnlyRule)
+            .addRules('timeout', staffOnlyRule)
             .addRules('modlog', staffOnlyRule)
             .addRules('pardon', staffOnlyRule)
             .addRules('warn', staffOnlyRule)

--- a/src/bbtag/limits/GeneralAutoResponseLimit.ts
+++ b/src/bbtag/limits/GeneralAutoResponseLimit.ts
@@ -12,6 +12,7 @@ export class GeneralAutoResponseLimit extends GlobalLimit {
             .addRules('unban', staffOnlyRule)
             .addRules('guildbans', staffOnlyRule)
             .addRules('kick', staffOnlyRule)
+            .addRules('timeout', staffOnlyRule)
             .addRules('modlog', staffOnlyRule)
             .addRules('pardon', staffOnlyRule)
             .addRules('warn', staffOnlyRule)

--- a/src/bbtag/limits/GlobalLimit.ts
+++ b/src/bbtag/limits/GlobalLimit.ts
@@ -14,6 +14,7 @@ export abstract class GlobalLimit extends BaseRuntimeLimit {
                 'edit',
                 'delete',
                 'kick',
+                'timeout',
                 'ban',
                 'reactadd',
                 'reactremove',

--- a/src/bbtag/limits/TagLimit.ts
+++ b/src/bbtag/limits/TagLimit.ts
@@ -14,6 +14,7 @@ export class TagLimit extends GlobalLimit {
             .addRules('unban', disabledRule)
             .addRules('guildbans', disabledRule)
             .addRules('kick', disabledRule)
+            .addRules('timeout', disabledRule)
             .addRules('modlog', disabledRule)
             .addRules('pardon', disabledRule)
             .addRules('warn', disabledRule)

--- a/src/cluster/events/discord/guildMemberUpdate.ts
+++ b/src/cluster/events/discord/guildMemberUpdate.ts
@@ -22,8 +22,8 @@ export class DiscordMemberUpdateHandler extends DiscordEventService<'guildMember
         if (oldMember.nick !== member.nick)
             promises.push(this.cluster.moderation.eventLog.nicknameUpdated(member, oldMember.nick ?? undefined));
 
-        if (member.communicationDisabledUntil !== oldMember.communicationDisabledUntil) {
-            if (member.communicationDisabledUntil !== null) {
+        if ((member.communicationDisabledUntil ?? null) !== (oldMember.communicationDisabledUntil ?? null)) {
+            if (typeof member.communicationDisabledUntil === 'number') {
                 const now = moment();
                 const memberTimeoutEndDate = moment(member.communicationDisabledUntil);
                 const duration = moment.duration(memberTimeoutEndDate.diff(now));

--- a/src/logger/test.ts
+++ b/src/logger/test.ts
@@ -1,0 +1,3 @@
+// export class Logger implements Console {
+
+// }

--- a/src/logger/test.ts
+++ b/src/logger/test.ts
@@ -1,3 +1,0 @@
-// export class Logger implements Console {
-
-// }


### PR DESCRIPTION
An issue with the docs in eris caused incorrect modlog entries to be fired, and we missed the usage restrictions for timeout.