### PR TITLE
Fix documentation sort order & only show exact matches

### DIFF
--- a/src/cluster/managers/documentation/DocumentationTreeManager.ts
+++ b/src/cluster/managers/documentation/DocumentationTreeManager.ts
@@ -49,10 +49,10 @@ export abstract class DocumentationTreeManager extends DocumentationManager {
         }
 
         const exact = matches.filter(m => m.score === Number.MAX_SAFE_INTEGER);
-        if (exact.length === 1)
+        if (exact.length > 0)
             return exact.map(x => x.item);
 
-        return matches.sort((a, b) => a.score - b.score).map(x => x.item);
+        return matches.sort((a, b) => b.score - a.score).map(x => x.item);
     }
 
     protected async getDocumentation(documentationId: string, user: User, channel: KnownTextableChannel): Promise<Documentation | undefined> {


### PR DESCRIPTION
Fixes an issue I noticed when doing `b!t docs json`
![image](https://user-images.githubusercontent.com/7736591/185749124-0fefa064-cf40-4b78-9fcb-a62911835f7d.png)
