### PR TITLE
Allow 1 message to trigger multiple censors

### DIFF
--- a/src/cluster/dcommands/admin/censor.ts
+++ b/src/cluster/dcommands/admin/censor.ts
@@ -1,6 +1,6 @@
 import { GuildCommand } from '@blargbot/cluster/command';
 import { GuildCommandContext } from '@blargbot/cluster/types';
-import { CommandType } from '@blargbot/cluster/utils';
+import { CommandType, ModerationType } from '@blargbot/cluster/utils';
 import { SendContent } from '@blargbot/core/types';
 import { codeBlock, guard } from '@blargbot/core/utils';
 import { GuildCensor, GuildTriggerTag } from '@blargbot/domain/models';
@@ -352,4 +352,4 @@ function stringifyCensorEvent(event: GuildTriggerTag | undefined): string {
     return `Author: <@${event.author ?? 0}>\nAuthorizer: <@${event.authorizer ?? event.author ?? '????'}>`;
 }
 
-const allowedTypes = new Set(['timeout', 'kick', 'ban', 'delete'] as const);
+const allowedTypes = new Set<ModerationType>([ModerationType.BAN, ModerationType.KICK, ModerationType.TIMEOUT, ModerationType.WARN] as const);

--- a/src/cluster/utils/constants/moderationType.ts
+++ b/src/cluster/utils/constants/moderationType.ts
@@ -1,6 +1,6 @@
 export enum ModerationType {
-    WARN = 0,
-    BAN = 1,
-    KICK = 2,
-    TIMEOUT = 3
+    WARN = 'delete',
+    BAN = 'ban',
+    KICK = 'kick',
+    TIMEOUT = 'timeout'
 }


### PR DESCRIPTION
This is a regression from how blargbot used to work. Autoresponses also used to run regardless of the message being censored, but now they dont. Im choosing not to fix that as there is an easy workaround for that - {exec}

Fixes [Autoresponse and censor conflict](https://discord.com/channels/194232473931087872/1004925794860150836)