### PR TITLE
channeledit/create json should allow strings

### DIFF
--- a/src/bbtag/subtags/channel/channeledit.ts
+++ b/src/bbtag/subtags/channel/channeledit.ts
@@ -66,6 +66,8 @@ export class ChannelEditSubtag extends CompiledSubtag {
     }
 }
 
+const defaultAutoArchiveDurationMapping = mapping.in(...[60, 1440, 4320, 10080, undefined] as const);
+
 const mapChannelOptions = mapping.json(
     mapping.object<EditChannelOptions>({
         bitrate: mapping.number.optional,
@@ -75,7 +77,7 @@ const mapChannelOptions = mapping.json(
         rateLimitPerUser: mapping.number.optional,
         topic: mapping.string.optional,
         userLimit: mapping.number.optional,
-        defaultAutoArchiveDuration: mapping.in(60, 1440, 4320, 10080, undefined),
+        defaultAutoArchiveDuration: mapping.number.chain(defaultAutoArchiveDurationMapping).optional,
         locked: mapping.boolean.optional,
         rtcRegion: [undefined],
         archived: [undefined],
@@ -91,7 +93,7 @@ const mapChannelOptions = mapping.json(
 const mapThreadOptions = mapping.json(
     mapping.object<EditChannelOptions>({
         archived: mapping.boolean.optional,
-        autoArchiveDuration: mapping.in(60, 1440, 4320, 10080, undefined),
+        autoArchiveDuration: mapping.number.chain(defaultAutoArchiveDurationMapping).optional,
         locked: mapping.boolean.optional,
         name: mapping.string.optional,
         rateLimitPerUser: mapping.number.optional,

--- a/src/mapping/mapBoolean.ts
+++ b/src/mapping/mapBoolean.ts
@@ -2,7 +2,17 @@ import { createMapping } from './createMapping';
 import { result } from './result';
 
 export const mapBoolean = createMapping<boolean>(value => {
-    return typeof value === 'boolean'
-        ? result.success(value)
-        : result.failed;
+    switch (typeof value) {
+        case 'boolean':
+            return result.success(value);
+        case 'string':
+            switch (value.toLowerCase()) {
+                case 'true':
+                    return result.success(true);
+                case 'false':
+                    return result.success(false);
+            }
+            break;
+    }
+    return result.failed;
 });

--- a/src/mapping/mapNumber.ts
+++ b/src/mapping/mapNumber.ts
@@ -1,9 +1,19 @@
 import { createMapping } from './createMapping';
 import { result } from './result';
-import { TypeMapping } from './types';
 
-export const mapNumber: TypeMapping<number> = createMapping(value => {
-    return typeof value === 'number'
-        ? result.success(value)
-        : result.failed;
+export const mapNumber = createMapping<number>(value => {
+    switch (typeof value) {
+        case 'number':
+            if (isNaN(value))
+                return result.failed;
+            return result.success(value);
+        case 'string': {
+            const res = parseFloat(value);
+            if (isNaN(res))
+                return result.failed;
+            return result.success(res);
+        }
+        default:
+            return result.failed;
+    }
 });

--- a/test/bbtag/subtags/channel/channelcreate.test.ts
+++ b/test/bbtag/subtags/channel/channelcreate.test.ts
@@ -135,6 +135,61 @@ runSubtagTests({
                         userLimit: 32042430
                     }), undefined)).thenResolve(channel.instance);
                 }
+            },
+            {
+                code: `{channelcreate;My new channel;${type};{escapebbtag;${JSON.stringify({
+                    bitrate: '1234',
+                    nsfw: 'true',
+                    parentID: '23987233279389273',
+                    permissionOverwrites: [
+                        {
+                            id: '329478923748223',
+                            allow: '3827468274',
+                            deny: '42937843478',
+                            type: 'role'
+                        },
+                        {
+                            id: '9054786496875634',
+                            allow: '23432424',
+                            deny: '432434234',
+                            type: 'member'
+                        }
+                    ],
+                    rateLimitPerUser: '231432',
+                    topic: 'xyz123',
+                    reason: 'abcdef',
+                    userLimit: '32042430'
+                })}}}`,
+                expected: '28376128632132',
+                subtags: [new EscapeBbtagSubtag()],
+                setup(ctx: SubtagTestContext) {
+                    const channel = ctx.createMock<Channel>(instance);
+                    channel.setup(m => m.id).thenReturn('28376128632132');
+
+                    ctx.discord.setup(m => m.createChannel(ctx.guild.id, 'My new channel', code, argument.isDeepEqual({
+                        bitrate: 1234,
+                        nsfw: true,
+                        parentID: '23987233279389273',
+                        permissionOverwrites: [
+                            {
+                                id: '329478923748223',
+                                allow: 3827468274n,
+                                deny: 42937843478n,
+                                type: OverwriteType.Role
+                            },
+                            {
+                                id: '9054786496875634',
+                                allow: 23432424n,
+                                deny: 432434234n,
+                                type: OverwriteType.Member
+                            }
+                        ],
+                        rateLimitPerUser: 231432,
+                        topic: 'xyz123',
+                        reason: 'abcdef',
+                        userLimit: 32042430
+                    }), undefined)).thenResolve(channel.instance);
+                }
             }
         ]),
         {

--- a/test/bbtag/subtags/channel/channeledit.test.ts
+++ b/test/bbtag/subtags/channel/channeledit.test.ts
@@ -168,6 +168,92 @@ runSubtagTests({
             }
         },
         {
+            title: 'Channel is not a thread',
+            code: `{channeledit;1293671282973698;{escapebbtag;${JSON.stringify({
+                bitrate: '123',
+                name: 'new channel name',
+                nsfw: 'true',
+                parentID: '2836742834628346',
+                rateLimitPerUser: '456',
+                topic: 'New channel topic',
+                userLimit: '789',
+                defaultAutoArchiveDuration: '1440',
+                locked: 'true'
+            })}}}`,
+            expected: '1293671282973698',
+            subtags: [new EscapeBbtagSubtag()],
+            setup(ctx) {
+                ctx.channels.general.id = '1293671282973698';
+            },
+            postSetup(bbctx, ctx) {
+                const channel = bbctx.guild.channels.get(ctx.channels.general.id);
+                if (channel === undefined)
+                    throw new Error('Unable to get channel under test');
+
+                ctx.util.setup(m => m.findChannels(bbctx.guild, '1293671282973698')).thenResolve([channel]);
+                ctx.discord.setup(m => m.editChannel(channel.id, argument.isDeepEqual({
+                    bitrate: 123,
+                    name: 'new channel name',
+                    nsfw: true,
+                    parentID: '2836742834628346',
+                    rateLimitPerUser: 456,
+                    topic: 'New channel topic',
+                    userLimit: 789,
+                    defaultAutoArchiveDuration: 1440,
+                    locked: true,
+                    rtcRegion: undefined,
+                    archived: undefined,
+                    autoArchiveDuration: undefined,
+                    icon: undefined,
+                    invitable: undefined,
+                    ownerID: undefined,
+                    videoQualityMode: undefined
+                }), 'Command User#0000')).thenResolve(channel);
+            }
+        },
+        {
+            title: 'Channel is a thread',
+            code: `{channeledit;1293671282973698;{escapebbtag;${JSON.stringify({
+                archived: 'true',
+                autoArchiveDuration: '4320',
+                locked: 'true',
+                name: 'New thread name',
+                rateLimitPerUser: '123',
+                invitable: 'true'
+            })}}}`,
+            expected: '1293671282973698',
+            subtags: [new EscapeBbtagSubtag()],
+            setup(ctx) {
+                ctx.channels.general.id = '1293671282973698';
+                ctx.channels.general.type = ChannelType.GuildPublicThread;
+            },
+            postSetup(bbctx, ctx) {
+                const channel = bbctx.guild.channels.get(ctx.channels.general.id);
+                if (channel === undefined)
+                    throw new Error('Unable to get channel under test');
+
+                ctx.util.setup(m => m.findChannels(bbctx.guild, '1293671282973698')).thenResolve([channel]);
+                ctx.discord.setup(m => m.editChannel(channel.id, argument.isDeepEqual({
+                    archived: true,
+                    autoArchiveDuration: 4320,
+                    locked: true,
+                    name: 'New thread name',
+                    rateLimitPerUser: 123,
+                    invitable: true,
+                    bitrate: undefined,
+                    defaultAutoArchiveDuration: undefined,
+                    icon: undefined,
+                    nsfw: undefined,
+                    ownerID: undefined,
+                    parentID: undefined,
+                    rtcRegion: undefined,
+                    topic: undefined,
+                    userLimit: undefined,
+                    videoQualityMode: undefined
+                }), 'Command User#0000')).thenResolve(channel);
+            }
+        },
+        {
             code: '{channeledit;1293671282973698}',
             expected: '`Channel does not exist`',
             errors: [


### PR DESCRIPTION
Fixes [{channeledit} seems broken... returns 'Invalid JSON' when trying to set rateLimitPerUser](https://discord.com/channels/194232473931087872/1012176276385185853)