### PR TITLE
Potentially fix member edit race condition

### DIFF
--- a/src/bbtag/subtags/role/roleadd.ts
+++ b/src/bbtag/subtags/role/roleadd.ts
@@ -64,7 +64,9 @@ export class RoleAddSubtag extends CompiledSubtag {
             return false;
 
         try {
-            await member.edit({ roles: member.roles.concat(...roles.map(r => r.id)) }, context.auditReason());
+            const newRoleList = [...new Set([...member.roles, ...roles.map(r => r.id)])];
+            await member.edit({ roles: newRoleList }, context.auditReason());
+            member.roles = newRoleList;
             return true;
         } catch (err: unknown) {
             context.logger.error(err);

--- a/src/bbtag/subtags/role/roleremove.ts
+++ b/src/bbtag/subtags/role/roleremove.ts
@@ -64,8 +64,10 @@ export class RoleRemoveSubtag extends CompiledSubtag {
             return false;
 
         try {
-            const roleIds = new Set(roles.map(r => r.id));
-            await member.edit({ roles: member.roles.filter(roleID => !roleIds.has(roleID)) }, context.auditReason());
+            const removeRoles = new Set(roles.map(r => r.id));
+            const newRoleList = [...new Set(member.roles.filter(r => !removeRoles.has(r)))];
+            await member.edit({ roles: newRoleList }, context.auditReason());
+            member.roles = newRoleList;
             return true;
         } catch (err: unknown) {
             context.logger.error(err);

--- a/src/bbtag/subtags/user/usersetnick.ts
+++ b/src/bbtag/subtags/user/usersetnick.ts
@@ -30,6 +30,7 @@ export class UserSetNickSubtag extends CompiledSubtag {
 
         try {
             await member.edit({ nick }, context.auditReason());
+            member.nick = nick;
         } catch (err: unknown) {
             context.logger.error(err);
             if (err instanceof Error)

--- a/src/bbtag/subtags/user/usersetroles.ts
+++ b/src/bbtag/subtags/user/usersetroles.ts
@@ -79,6 +79,7 @@ export class UserSetRolesSubtag extends CompiledSubtag {
 
         try {
             await member.edit({ roles: parsedRoles }, context.auditReason());
+            member.roles = parsedRoles;
             return true;
         } catch (err: unknown) {
             context.logger.error(err);

--- a/src/cluster/dcommands/general/decancer.ts
+++ b/src/cluster/dcommands/general/decancer.ts
@@ -36,6 +36,7 @@ export class DecancerCommand extends GlobalCommand {
         const decancered = humanize.decancer(member.nick ?? member.username);
         try {
             await member.edit({ nick: decancered });
+            member.nick = decancered;
             return this.success(`Successfully decancered **${member.mention}**'s name to: \`${decancered}\``);
         } catch {
             return this.decancerText(member.nick ?? member.username, decancered);

--- a/src/cluster/managers/RolemeManager.ts
+++ b/src/cluster/managers/RolemeManager.ts
@@ -29,7 +29,9 @@ export class RolemeManager {
             roleme.remove.forEach(r => roleList.delete(r));
 
             try {
-                await message.member.edit({ roles: [...roleList] });
+                const newRoleList = [...roleList];
+                await message.member.edit({ roles: newRoleList });
+                message.member.roles = newRoleList;
                 await this.invokeMessage(message, roleme);
 
             } catch (err: unknown) {


### PR DESCRIPTION
It would seem that calling `Member#edit` doesnt cause eris to ensure the member is edited before resolving the promise. I think this is causing a race condition in some situations. This PR hopefully fixes [Something screwy going on with {jget} or {roleadd} and {roleremove}](https://discord.com/channels/194232473931087872/1012147398333706363) but will need testing once deployed to be sure