### PR TITLE
Add extension parameter to the bbtag raw commands

### DIFF
--- a/src/cluster/dcommands/admin/autoresponse.ts
+++ b/src/cluster/dcommands/admin/autoresponse.ts
@@ -125,7 +125,7 @@ export class AutoResponseCommand extends GuildCommand {
         const responseBase = `The raw code for ${match.id === 'everything' ? 'the everything autoresponse' : `autoresponse ${match.id}`} is`;
 
         const response = this.success(`${responseBase}:\n${codeBlock(match.ar.content)}`);
-        return guard.checkMessageSize(response)
+        return !match.ar.content.includes('`') && guard.checkMessageSize(response)
             ? response
             : {
                 content: this.success(`${responseBase} attached`),

--- a/src/cluster/dcommands/admin/autoresponse.ts
+++ b/src/cluster/dcommands/admin/autoresponse.ts
@@ -60,9 +60,9 @@ export class AutoResponseCommand extends GuildCommand {
                     execute: (ctx, [id, bbtag]) => this.setBBTag(ctx, id.asString, bbtag.asString)
                 },
                 {
-                    parameters: 'raw {id}',
+                    parameters: 'raw {id} {fileExtension:literal(bbtag|txt)=bbtag}',
                     description: 'Gets the bbtag that is executed when the autoresponse is triggered',
-                    execute: (ctx, [id]) => this.getRaw(ctx, id.asString)
+                    execute: (ctx, [id, fileExtension]) => this.getRaw(ctx, id.asString, fileExtension.asLiteral)
                 },
                 {
                     parameters: 'setauthorizer {id}',
@@ -113,7 +113,7 @@ export class AutoResponseCommand extends GuildCommand {
         return this.success(`Updated the code for ${id === 'everything' ? 'the everything autoresponse' : `autoresponse ${id}`}`);
     }
 
-    public async getRaw(context: GuildCommandContext, id: string): Promise<string | SendContent> {
+    public async getRaw(context: GuildCommandContext, id: string, fileExtension: string): Promise<string | SendContent> {
         const accessError = this.checkArAccess(context);
         if (accessError !== undefined)
             return accessError;
@@ -131,7 +131,7 @@ export class AutoResponseCommand extends GuildCommand {
                 content: this.success(`${responseBase} attached`),
                 files: [
                     {
-                        name: `autoresponse_${match.id}.bbtag`,
+                        name: `autoresponse_${match.id}.${fileExtension}`,
                         file: match.ar.content
                     }
                 ]

--- a/src/cluster/dcommands/admin/ccommand.ts
+++ b/src/cluster/dcommands/admin/ccommand.ts
@@ -283,7 +283,7 @@ export class CustomCommandCommand extends GuildCommand {
             return this.error(`The command \`${match.name}\` is an alias to the tag \`${match.alias}\``);
 
         const response = this.info(`The raw code for \`${match.name}\` is:\n${codeBlock(match.content)}`);
-        return guard.checkMessageSize(response)
+        return !match.content.includes('`') && guard.checkMessageSize(response)
             ? response
             : {
                 content: this.info(`The raw code for \`${match.name}\` is attached`),

--- a/src/cluster/dcommands/admin/ccommand.ts
+++ b/src/cluster/dcommands/admin/ccommand.ts
@@ -82,8 +82,8 @@ export class CustomCommandCommand extends GuildCommand {
                     description: 'Renames the custom command'
                 },
                 {
-                    parameters: 'raw {commandName?}',
-                    execute: (ctx, [commandName]) => this.getRawCommand(ctx, commandName.asOptionalString),
+                    parameters: 'raw {commandName?} {fileExtension:literal(bbtag|txt)=bbtag}',
+                    execute: (ctx, [commandName, fileExtension]) => this.getRawCommand(ctx, commandName.asOptionalString, fileExtension.asLiteral),
                     description: 'Gets the raw content of the custom command'
                 },
                 {
@@ -274,7 +274,7 @@ export class CustomCommandCommand extends GuildCommand {
         return this.success(`The \`${from.name}\` custom command has been renamed to \`${to.name}\`.`);
     }
 
-    public async getRawCommand(context: GuildCommandContext, commandName: string | undefined): Promise<string | { content: string; files: FileContent[]; } | undefined> {
+    public async getRawCommand(context: GuildCommandContext, commandName: string | undefined, fileExtension: string): Promise<string | { content: string; files: FileContent[]; } | undefined> {
         const match = await this.requestReadableCommand(context, commandName);
         if (typeof match !== 'object')
             return match;
@@ -289,7 +289,7 @@ export class CustomCommandCommand extends GuildCommand {
                 content: this.info(`The raw code for \`${match.name}\` is attached`),
                 files: [
                     {
-                        name: match.name + '.bbtag',
+                        name: `${match.name}.${fileExtension}`,
                         file: match.content
                     }
                 ]

--- a/src/cluster/dcommands/admin/censor.ts
+++ b/src/cluster/dcommands/admin/censor.ts
@@ -251,7 +251,7 @@ export class CensorCommand extends GuildCommand {
 
         const response = this.info(`${message}:\n${codeBlock(rule.content)}`);
 
-        return guard.checkMessageSize(response)
+        return !rule.content.includes('`') && guard.checkMessageSize(response)
             ? response
             : {
                 content: this.info(`${message} attached`),

--- a/src/cluster/dcommands/admin/censor.ts
+++ b/src/cluster/dcommands/admin/censor.ts
@@ -69,9 +69,9 @@ export class CensorCommand extends GuildCommand {
                     execute: (ctx, [id, type]) => this.setAuthorizer(ctx, id.asOptionalInteger, type.asLiteral)
                 },
                 {
-                    parameters: 'rawmessage {id:integer?} {type:literal(delete|timeout|kick|ban)}',
+                    parameters: 'rawmessage {id:integer?} {type:literal(delete|timeout|kick|ban)} {fileExtension:literal(bbtag|txt)=bbtag}',
                     description: 'Gets the raw code for the given censor',
-                    execute: (ctx, [id, type]) => this.getRawMessage(ctx, id.asOptionalInteger, type.asLiteral)
+                    execute: (ctx, [id, type, fileExtension]) => this.getRawMessage(ctx, id.asOptionalInteger, type.asLiteral, fileExtension.asLiteral)
                 },
                 {
                     parameters: 'debug {id:integer} {type:literal(delete|timeout|kick|ban)}',
@@ -233,7 +233,7 @@ export class CensorCommand extends GuildCommand {
         );
     }
 
-    public async getRawMessage(context: GuildCommandContext, id: number | undefined, type: string): Promise<string | SendContent> {
+    public async getRawMessage(context: GuildCommandContext, id: number | undefined, type: string, fileExtension: string): Promise<string | SendContent> {
         if (!allowedTypes.has(type))
             return this.error(`\`${type}\` is not a valid type`);
 
@@ -257,7 +257,7 @@ export class CensorCommand extends GuildCommand {
                 content: this.info(`${message} attached`),
                 files: [
                     {
-                        name: `censor-${type}-${id ?? 'default'}.bbtag`,
+                        name: `censor-${type}-${id ?? 'default'}.${fileExtension}`,
                         file: rule.content
                     }
                 ]

--- a/src/cluster/dcommands/admin/farewell.ts
+++ b/src/cluster/dcommands/admin/farewell.ts
@@ -17,9 +17,9 @@ export class FarewellCommand extends GuildCommand {
                     execute: (ctx, [bbtag]) => this.setFarewell(ctx, bbtag.asString)
                 },
                 {
-                    parameters: 'raw',
+                    parameters: 'raw {fileExtension:literal(bbtag|txt)=bbtag}',
                     description: 'Gets the current message that will be sent when someone leaves the server',
-                    execute: (ctx) => this.getFarewell(ctx)
+                    execute: (ctx, [fileExtension]) => this.getFarewell(ctx, fileExtension.asLiteral)
                 },
                 {
                     parameters: 'setauthorizer',
@@ -70,7 +70,7 @@ export class FarewellCommand extends GuildCommand {
         return this.success('The farewell message has been set');
     }
 
-    public async getFarewell(context: GuildCommandContext): Promise<string | SendContent> {
+    public async getFarewell(context: GuildCommandContext, fileExtension: string): Promise<string | SendContent> {
         const farewell = await context.database.guilds.getFarewell(context.channel.guild.id);
         if (farewell === undefined)
             return this.error('No farewell message has been set yet!');
@@ -88,7 +88,7 @@ export class FarewellCommand extends GuildCommand {
                 content: this.info(`${message} attached`),
                 files: [
                     {
-                        name: 'farewell.bbtag',
+                        name: `farewell.${fileExtension}`,
                         file: farewell.content
                     }
                 ]

--- a/src/cluster/dcommands/admin/farewell.ts
+++ b/src/cluster/dcommands/admin/farewell.ts
@@ -82,7 +82,7 @@ export class FarewellCommand extends GuildCommand {
             : `The raw code for the farewell message (sent in ${channel.mention}) is`;
         const response = this.info(`${message}:\n${codeBlock(farewell.content)}`);
 
-        return guard.checkMessageSize(response)
+        return !farewell.content.includes('`') && guard.checkMessageSize(response)
             ? response
             : {
                 content: this.info(`${message} attached`),

--- a/src/cluster/dcommands/admin/greeting.ts
+++ b/src/cluster/dcommands/admin/greeting.ts
@@ -83,7 +83,7 @@ export class GreetingCommand extends GuildCommand {
             : `The raw code for the greeting message (sent in ${channel.mention}) is`;
         const response = this.info(`${message}:\n${codeBlock(greeting.content)}`);
 
-        return guard.checkMessageSize(response)
+        return !greeting.content.includes('`') && guard.checkMessageSize(response)
             ? response
             : {
                 content: this.info(`${message} attached`),

--- a/src/cluster/dcommands/admin/greeting.ts
+++ b/src/cluster/dcommands/admin/greeting.ts
@@ -18,9 +18,9 @@ export class GreetingCommand extends GuildCommand {
                     execute: (ctx, [bbtag]) => this.setGreeting(ctx, bbtag.asString)
                 },
                 {
-                    parameters: 'raw',
+                    parameters: 'raw {fileExtension:literal(bbtag|txt)=bbtag}',
                     description: 'Gets the current message that will be sent when someone joins the server',
-                    execute: (ctx) => this.getGreeting(ctx)
+                    execute: (ctx, [fileExtension]) => this.getGreeting(ctx, fileExtension.asLiteral)
                 },
                 {
                     parameters: 'setauthorizer',
@@ -71,7 +71,7 @@ export class GreetingCommand extends GuildCommand {
         return this.success('The greeting message has been set');
     }
 
-    public async getGreeting(context: GuildCommandContext): Promise<string | SendContent> {
+    public async getGreeting(context: GuildCommandContext, fileExtension: string): Promise<string | SendContent> {
         const greeting = await context.database.guilds.getGreeting(context.channel.guild.id);
         if (greeting === undefined)
             return this.error('No greeting message has been set yet!');
@@ -89,7 +89,7 @@ export class GreetingCommand extends GuildCommand {
                 content: this.info(`${message} attached`),
                 files: [
                     {
-                        name: 'greeting.bbtag',
+                        name: `greeting.${fileExtension}`,
                         file: greeting.content
                     }
                 ]

--- a/src/cluster/dcommands/admin/interval.ts
+++ b/src/cluster/dcommands/admin/interval.ts
@@ -17,9 +17,9 @@ export class IntervalCommand extends GuildCommand {
                     execute: (ctx, [bbtag]) => this.setInterval(ctx, bbtag.asString)
                 },
                 {
-                    parameters: 'raw',
+                    parameters: 'raw {fileExtension:literal(bbtag|txt)=bbtag}',
                     description: 'Gets the current code that the interval is running',
-                    execute: (ctx) => this.getRaw(ctx)
+                    execute: (ctx, [fileExtension]) => this.getRaw(ctx, fileExtension.asLiteral)
                 },
                 {
                     parameters: 'delete',
@@ -69,7 +69,7 @@ export class IntervalCommand extends GuildCommand {
         return this.success('The interval has been deleted');
     }
 
-    public async getRaw(context: GuildCommandContext): Promise<string | SendContent> {
+    public async getRaw(context: GuildCommandContext, fileExtension: string): Promise<string | SendContent> {
         const interval = await context.database.guilds.getInterval(context.channel.guild.id);
         if (interval === undefined)
             return this.error('There is no interval currently set up!');
@@ -81,7 +81,7 @@ export class IntervalCommand extends GuildCommand {
                 content: this.info('The raw code for the interval is attached'),
                 files: [
                     {
-                        name: 'interval.bbtag',
+                        name: `interval.${fileExtension}`,
                         file: interval.content
                     }
                 ]

--- a/src/cluster/dcommands/admin/interval.ts
+++ b/src/cluster/dcommands/admin/interval.ts
@@ -75,7 +75,7 @@ export class IntervalCommand extends GuildCommand {
             return this.error('There is no interval currently set up!');
 
         const response = this.info(`The raw code for the interval is:\n${codeBlock(interval.content)}`);
-        return guard.checkMessageSize(response)
+        return !interval.content.includes('`') && guard.checkMessageSize(response)
             ? response
             : {
                 content: this.info('The raw code for the interval is attached'),

--- a/src/cluster/dcommands/admin/roleme.ts
+++ b/src/cluster/dcommands/admin/roleme.ts
@@ -262,7 +262,7 @@ export class RolemeCommand extends GuildCommand {
             return this.error(`Roleme ${id} doesnt have a custom message`);
 
         const response = this.info(`The raw code for the interval is:\n${codeBlock(roleme.output.content)}`);
-        return guard.checkMessageSize(response)
+        return !roleme.output.content.includes('`') && guard.checkMessageSize(response)
             ? response
             : {
                 content: this.info('The raw code for the interval is attached'),

--- a/src/cluster/dcommands/admin/roleme.ts
+++ b/src/cluster/dcommands/admin/roleme.ts
@@ -43,9 +43,9 @@ export class RolemeCommand extends GuildCommand {
                     execute: (ctx, [id, bbtag]) => this.setMessage(ctx, id.asInteger, bbtag.asOptionalString)
                 },
                 {
-                    parameters: 'rawmessage {rolemeId:integer}',
+                    parameters: 'rawmessage {rolemeId:integer} {fileExtension:literal(bbtag|txt)=bbtag}',
                     description: 'Gets the current message that will be sent when the roleme is triggered',
-                    execute: (ctx, [id]) => this.getRawMessage(ctx, id.asInteger)
+                    execute: (ctx, [id, fileExtension]) => this.getRawMessage(ctx, id.asInteger, fileExtension.asLiteral)
                 },
                 {
                     parameters: 'debugmessage {rolemeId:integer}',
@@ -253,7 +253,7 @@ export class RolemeCommand extends GuildCommand {
         return this.success(`Roleme ${id} has now had its message set`);
     }
 
-    public async getRawMessage(context: GuildCommandContext, id: number): Promise<string | SendContent> {
+    public async getRawMessage(context: GuildCommandContext, id: number, fileExtension: string): Promise<string | SendContent> {
         const roleme = await context.database.guilds.getRoleme(context.channel.guild.id, id);
         if (roleme === undefined)
             return this.error(`Roleme ${id} doesnt exist`);
@@ -268,7 +268,7 @@ export class RolemeCommand extends GuildCommand {
                 content: this.info('The raw code for the interval is attached'),
                 files: [
                     {
-                        name: 'interval.bbtag',
+                        name: `interval.${fileExtension}`,
                         file: roleme.output.content
                     }
                 ]

--- a/src/cluster/dcommands/general/tag.ts
+++ b/src/cluster/dcommands/general/tag.ts
@@ -307,7 +307,7 @@ export class TagCommand extends GuildCommand {
             return match;
 
         const response = this.info(`The raw code for \`${match.name}\` is:\n\`\`\`${match.lang ?? ''}\n${match.content}\n\`\`\``);
-        return guard.checkMessageSize(response)
+        return !match.content.includes('`') && guard.checkMessageSize(response)
             ? response
             : {
                 content: this.info(`The raw code for \`${match.name}\` is attached`),

--- a/src/cluster/dcommands/general/tag.ts
+++ b/src/cluster/dcommands/general/tag.ts
@@ -79,8 +79,8 @@ export class TagCommand extends GuildCommand {
                     description: 'Renames the tag'
                 },
                 {
-                    parameters: 'raw {tagName?}',
-                    execute: (ctx, [tagName]) => this.getRawTag(ctx, tagName.asOptionalString),
+                    parameters: 'raw {tagName?} {fileExtension:literal(bbtag|txt)=bbtag}',
+                    execute: (ctx, [tagName, fileExtension]) => this.getRawTag(ctx, tagName.asOptionalString, fileExtension.asLiteral),
                     description: 'Uses the BBTag engine to execute the content as it was a tag'
                 },
                 {
@@ -301,7 +301,7 @@ export class TagCommand extends GuildCommand {
         return this.success(`The \`${from.name}\` tag has been renamed to \`${to.name}\`.`);
     }
 
-    public async getRawTag(context: GuildCommandContext, tagName: string | undefined): Promise<string | { content: string; files: FileContent[]; } | undefined> {
+    public async getRawTag(context: GuildCommandContext, tagName: string | undefined, fileExtension: string): Promise<string | { content: string; files: FileContent[]; } | undefined> {
         const match = await this.requestReadableTag(context, tagName);
         if (typeof match !== 'object')
             return match;
@@ -313,7 +313,7 @@ export class TagCommand extends GuildCommand {
                 content: this.info(`The raw code for \`${match.name}\` is attached`),
                 files: [
                     {
-                        name: match.name + '.bbtag',
+                        name: `${match.name}.${fileExtension}`,
                         file: match.content
                     }
                 ]


### PR DESCRIPTION
Allows you to specify the file type for the `raw` commands when getting bbtag.
Implements [#814](https://airtable.com/appKTYe5luRw2aoas/tblyFuWE6fEAbaOfo/viwDg5WovcwMA9NIL/reczTF7VBRsv9mmAQ)