### PR TITLE
editcommand list needs to provide a location

### DIFF
--- a/src/cluster/dcommands/admin/editcommand.ts
+++ b/src/cluster/dcommands/admin/editcommand.ts
@@ -56,7 +56,7 @@ export class EditCommandCommand extends GuildCommand {
         const commandNames = new Set<string>();
         const defaultPerms = new Map<unknown, string>();
         const commands: ICommand[] = [];
-        for await (const result of context.cluster.commands.list()) {
+        for await (const result of context.cluster.commands.list(context.channel.guild)) {
             if (result.state === 'ALLOWED') {
                 defaultPerms.set(result.detail.command.implementation, result.detail.command.permission);
                 commands.push(result.detail.command);


### PR DESCRIPTION
`b!editcommand list` was showing edits to commands globally rather than for the current guild, of which there is never any. Good job me.
Thanks [Pippy#5263](https://discord.com/users/414367180667355146) for pointing out this one!