### PR TITLE
Add confirmation for staff editing someone elses tag

### DIFF
--- a/src/cluster/dcommands/general/tag.ts
+++ b/src/cluster/dcommands/general/tag.ts
@@ -663,8 +663,15 @@ export class TagCommand extends GuildCommand {
             return match;
 
         if (match.tag !== undefined
-            && !context.util.isBotStaff(context.author.id)
-            && match.tag.author !== context.author.id) {
+            && match.tag.author !== context.author.id
+            && !(context.util.isBotStaff(context.author.id) && await context.util.queryConfirm({
+                actors: [context.author],
+                context: context.channel,
+                prompt: { content: `You are not the owner of the \`${match.name}\`, are you sure you want to modify it?` },
+                confirm: 'Yes',
+                cancel: 'No',
+                fallback: false
+            }))) {
             return this.error(`You don't own the \`${match.name}\` tag!`);
         }
 


### PR DESCRIPTION
Adds a confirmation message to ensure staff dont accidentally edit/delete someone elses tag.