### PR TITLE
Add limits on command names and handle large command counts

### DIFF
--- a/definitions/rethinkdb/index.d.ts
+++ b/definitions/rethinkdb/index.d.ts
@@ -308,7 +308,7 @@ export module 'rethinkdb' {
         [K in string & keyof T]?: T[K] | FilterMap<T[K]>;
     }
 
-    export interface Expression<T> extends Writeable<T>, Operation<T>, HasFields<T, Expression<T>> {
+    export interface Expression<T> extends Writeable<T>, Operation<T>, HasFields<T, Expression<boolean>> {
         <K extends string & keyof T>(prop: K): Expression<T[K]>;
         <R extends readonly unknown[], K extends string & keyof R[number]>(this: Expression<R>, prop: K): Expression<Array<R[number][K]>>;
         merge<R>(query: R | Expression<R>): Expression<T & R>;

--- a/src/api/routes/guilds/ccommands.ts
+++ b/src/api/routes/guilds/ccommands.ts
@@ -66,8 +66,8 @@ export class CCommandsRoute extends BaseRoute {
     }
 
     async #createCommand(guildId: string, commandName: string, content: string, author: string): Promise<ApiResponse> {
-        if (commandName.length > 80)
-            return this.badRequest('name cannot be longer than 70 characters');
+        if (commandName.length > 100)
+            return this.badRequest('name cannot be longer than 100 characters');
 
         const success = await this.#api.database.guilds.setCommand(guildId, commandName, { content, author });
         if (!success)

--- a/src/api/routes/guilds/ccommands.ts
+++ b/src/api/routes/guilds/ccommands.ts
@@ -1,6 +1,7 @@
 import { Api } from '@blargbot/api/Api';
 import { BaseRoute } from '@blargbot/api/BaseRoute';
 import { ApiResponse } from '@blargbot/api/types';
+import { snowflake } from '@blargbot/core/utils/snowflake';
 import { GuildCommandTag, NamedGuildSourceCommandTag } from '@blargbot/domain/models';
 import { mapping } from '@blargbot/mapping';
 
@@ -69,7 +70,12 @@ export class CCommandsRoute extends BaseRoute {
         if (commandName.length > 100)
             return this.badRequest('name cannot be longer than 100 characters');
 
-        const success = await this.#api.database.guilds.setCommand(guildId, commandName, { content, author });
+        const success = await this.#api.database.guilds.setCommand(guildId, commandName, {
+            id: snowflake.create().toString(),
+            content,
+            author
+        });
+
         if (!success)
             return this.internalServerError('Failed to create custom command');
 

--- a/src/api/routes/guilds/ccommands.ts
+++ b/src/api/routes/guilds/ccommands.ts
@@ -66,6 +66,9 @@ export class CCommandsRoute extends BaseRoute {
     }
 
     async #createCommand(guildId: string, commandName: string, content: string, author: string): Promise<ApiResponse> {
+        if (commandName.length > 80)
+            return this.badRequest('name cannot be longer than 80 characters');
+
         const success = await this.#api.database.guilds.setCommand(guildId, commandName, { content, author });
         if (!success)
             return this.internalServerError('Failed to create custom command');

--- a/src/api/routes/guilds/ccommands.ts
+++ b/src/api/routes/guilds/ccommands.ts
@@ -67,7 +67,7 @@ export class CCommandsRoute extends BaseRoute {
 
     async #createCommand(guildId: string, commandName: string, content: string, author: string): Promise<ApiResponse> {
         if (commandName.length > 80)
-            return this.badRequest('name cannot be longer than 80 characters');
+            return this.badRequest('name cannot be longer than 70 characters');
 
         const success = await this.#api.database.guilds.setCommand(guildId, commandName, { content, author });
         if (!success)

--- a/src/cluster/dcommands/admin/ccommand.ts
+++ b/src/cluster/dcommands/admin/ccommand.ts
@@ -752,10 +752,13 @@ export class CustomCommandCommand extends GuildCommand {
             return undefined;
 
         const command = await context.database.guilds.getCommand(context.channel.guild.id, commandName);
-        if (command === undefined)
-            return { name: commandName };
+        if (command !== undefined)
+            return { name: command.name, command };
 
-        return { name: command.name, command };
+        if (commandName.length > 80)
+            return this.error('Command names cannot be longer than 80 characters');
+
+        return { name: commandName };
     }
 }
 

--- a/src/cluster/dcommands/admin/ccommand.ts
+++ b/src/cluster/dcommands/admin/ccommand.ts
@@ -755,8 +755,8 @@ export class CustomCommandCommand extends GuildCommand {
         if (command !== undefined)
             return { name: command.name, command };
 
-        if (commandName.length > 80)
-            return this.error('Command names cannot be longer than 70 characters');
+        if (commandName.length > 100)
+            return this.error('Command names cannot be longer than 100 characters');
 
         return { name: commandName };
     }

--- a/src/cluster/dcommands/admin/ccommand.ts
+++ b/src/cluster/dcommands/admin/ccommand.ts
@@ -2,7 +2,7 @@ import { bbtag } from '@blargbot/bbtag';
 import { Cluster } from '@blargbot/cluster';
 import { GuildCommand } from '@blargbot/cluster/command';
 import { CommandResult, CustomCommandShrinkwrap, GuildCommandContext, GuildShrinkwrap, ICommand, SignedGuildShrinkwrap } from '@blargbot/cluster/types';
-import { codeBlock, CommandType, guard, humanize, parse } from '@blargbot/cluster/utils';
+import { codeBlock, CommandType, guard, humanize, parse, snowflake } from '@blargbot/cluster/utils';
 import { Configuration } from '@blargbot/config';
 import { SendContent, SendPayload } from '@blargbot/core/types';
 import { FlagDefinition, NamedGuildCommandTag, NamedGuildSourceCommandTag } from '@blargbot/domain/models';
@@ -226,7 +226,7 @@ export class CustomCommandCommand extends GuildCommand {
         if (typeof match !== 'object')
             return match;
 
-        return await this.#saveCommand(context, 'created', match.name, content);
+        return await this.#saveCommand(context, 'created', undefined, match.name, content);
     }
 
     public async editCommand(context: GuildCommandContext, commandName: string | undefined, content: string | undefined): Promise<string | undefined> {
@@ -237,7 +237,7 @@ export class CustomCommandCommand extends GuildCommand {
         if (guard.isGuildImportedCommandTag(match))
             return this.error(`The \`${match.name}\` custom command is an alias to the tag \`${match.alias}\``);
 
-        return await this.#saveCommand(context, 'edited', match.name, content, match);
+        return await this.#saveCommand(context, 'edited', match.id, match.name, content, match);
     }
 
     public async deleteCommand(context: GuildCommandContext, commandName: string | undefined): Promise<string | undefined> {
@@ -257,7 +257,7 @@ export class CustomCommandCommand extends GuildCommand {
         if (guard.isGuildImportedCommandTag(match.command))
             return this.error(`The \`${match.name}\` custom command is an alias to the tag \`${match.command.alias}\``);
 
-        return await this.#saveCommand(context, 'set', match.name, content, match.command);
+        return await this.#saveCommand(context, 'set', match.command?.id, match.name, content, match.command);
     }
 
     public async renameCommand(context: GuildCommandContext, oldName: string | undefined, newName: string | undefined): Promise<string | undefined> {
@@ -468,6 +468,7 @@ export class CustomCommandCommand extends GuildCommand {
 
         const author = await context.database.users.get(tag.author);
         await context.database.guilds.setCommand(context.channel.guild.id, commandName, {
+            id: snowflake.create().toString(),
             author: tag.author,
             alias: tagName,
             authorizer: context.author.id
@@ -577,6 +578,7 @@ export class CustomCommandCommand extends GuildCommand {
             confirm.push(this.success(`Import the command \`${commandName}\``));
             importSteps.push(async () => {
                 await context.cluster.database.guilds.setCommand(guildId, commandName, {
+                    id: snowflake.create().toString(),
                     ...command,
                     author: context.author.id
                 });
@@ -609,6 +611,7 @@ export class CustomCommandCommand extends GuildCommand {
     async #saveCommand(
         context: GuildCommandContext,
         operation: string,
+        id: string | undefined,
         commandName: string,
         content: string | undefined,
         currentCommand?: NamedGuildSourceCommandTag
@@ -622,6 +625,7 @@ export class CustomCommandCommand extends GuildCommand {
             return this.error(`There were errors with the bbtag you provided!\n${bbtag.stringifyAnalysis(analysis)}`);
 
         const command = {
+            id: id ?? snowflake.create().toString(),
             content: content,
             author: context.author.id,
             authorizer: context.author.id,

--- a/src/cluster/dcommands/admin/ccommand.ts
+++ b/src/cluster/dcommands/admin/ccommand.ts
@@ -756,7 +756,7 @@ export class CustomCommandCommand extends GuildCommand {
             return { name: command.name, command };
 
         if (commandName.length > 80)
-            return this.error('Command names cannot be longer than 80 characters');
+            return this.error('Command names cannot be longer than 70 characters');
 
         return { name: commandName };
     }

--- a/src/cluster/managers/commands/CustomCommandManager.ts
+++ b/src/cluster/managers/commands/CustomCommandManager.ts
@@ -86,12 +86,13 @@ class NormalizedCommandTag implements ICommand<NamedGuildCommandTag> {
     public readonly permission: string;
     public readonly roles: readonly string[];
     public readonly hidden: boolean;
+    public readonly isOnWebsite: false;
 
     public constructor(
         public readonly implementation: NamedGuildCommandTag,
         public readonly tag: StoredTag | undefined
     ) {
-        this.id = implementation.name;
+        this.id = implementation.id;
         this.name = implementation.name;
         this.aliases = [];
         this.category = 'Custom';
@@ -102,6 +103,7 @@ class NormalizedCommandTag implements ICommand<NamedGuildCommandTag> {
         this.permission = this.implementation.permission ?? '0';
         this.roles = this.implementation.roles ?? [];
         this.hidden = this.implementation.hidden ?? false;
+        this.isOnWebsite = false;
     }
 
     public async execute(context: CommandContext): Promise<undefined> {

--- a/src/cluster/managers/commands/DefaultCommandManager.ts
+++ b/src/cluster/managers/commands/DefaultCommandManager.ts
@@ -89,6 +89,7 @@ class NormalizedCommand implements ICommand<Command> {
     public readonly hidden: boolean;
     public readonly category: string;
     public readonly flags: readonly FlagDefinition[];
+    public readonly isOnWebsite: boolean;
 
     public constructor(
         public readonly implementation: Command,
@@ -105,6 +106,7 @@ class NormalizedCommand implements ICommand<Command> {
         this.hidden = permissions.hidden ?? false;
         this.category = commandTypeDetails[implementation.category].name;
         this.flags = implementation.flags;
+        this.isOnWebsite = !this.hidden;
     }
 
     public async execute(context: CommandContext, next: NextMiddleware<CommandResult>): Promise<CommandResult> {

--- a/src/cluster/managers/documentation/CommandDocumentationManager.ts
+++ b/src/cluster/managers/documentation/CommandDocumentationManager.ts
@@ -176,7 +176,7 @@ export class CommandDocumentationManager extends DocumentationTreeManager {
             hidden: result.state !== 'ALLOWED',
             tags: [command.name, ...command.aliases],
             embed: {
-                url: `/commands#${command.name}`,
+                url: command.isOnWebsite ? `/commands#${command.name}` : undefined,
                 description: description.join('\n'),
                 color: this.#getColor(command.category)
             },

--- a/src/cluster/types.ts
+++ b/src/cluster/types.ts
@@ -52,6 +52,7 @@ export interface ICommand<T = unknown> extends ICommandDetails, IMiddleware<Comm
     readonly id: string;
     readonly name: string;
     readonly implementation: T;
+    readonly isOnWebsite: boolean;
 }
 
 export type Result<State, Detail = undefined, Optional extends boolean = Detail extends undefined ? true : false> = Optional extends false

--- a/src/domain/models/guilds/GuildCommandTagBase.ts
+++ b/src/domain/models/guilds/GuildCommandTagBase.ts
@@ -2,6 +2,7 @@ import { CommandPermissions } from './CommandPermissions';
 import { GuildTagBase } from './GuildTagBase';
 
 export interface GuildCommandTagBase extends GuildTagBase, CommandPermissions {
+    readonly id: string;
     readonly help?: string;
     readonly cooldown?: number;
 }

--- a/test/bbtag/subtags/bot/execcc.test.ts
+++ b/test/bbtag/subtags/bot/execcc.test.ts
@@ -36,6 +36,7 @@ runSubtagTests({
                 ctx.options.inputRaw = 'This is some input text';
                 ctx.options.data = { stackSize: 100 };
                 ctx.ccommands['othersubtag'] = {
+                    id: '0',
                     author: '212097368371683623',
                     content: '{assert}{eval}',
                     cooldown: 7
@@ -78,6 +79,7 @@ runSubtagTests({
                 ctx.options.inputRaw = 'This is some input text';
                 ctx.options.data = { stackSize: 100 };
                 ctx.ccommands['othersubtag'] = {
+                    id: '0',
                     author: '212097368371683623',
                     content: '{assert}{eval}'
                 };
@@ -118,6 +120,7 @@ runSubtagTests({
                 ctx.options.inputRaw = 'This is some input text';
                 ctx.options.data = { stackSize: 100 };
                 ctx.ccommands['othersubtag'] = {
+                    id: '0',
                     author: '212097368371683623',
                     content: '{assert}{eval}',
                     cooldown: 7
@@ -159,6 +162,7 @@ runSubtagTests({
                 ctx.options.inputRaw = 'This is some input text';
                 ctx.options.data = { stackSize: 100 };
                 ctx.ccommands['othersubtag'] = {
+                    id: '0',
                     author: '212097368371683623',
                     content: '{assert}{eval}',
                     cooldown: 7
@@ -190,6 +194,7 @@ runSubtagTests({
             ],
             setup(ctx) {
                 ctx.ccommands['othersubtag'] = {
+                    id: '0',
                     author: '212097368371683623',
                     content: '{assert}{eval}',
                     alias: 'otherSubtag',
@@ -206,6 +211,7 @@ runSubtagTests({
             setup(ctx) {
                 ctx.options.data = { stackSize: 200 };
                 ctx.ccommands['othersubtag'] = {
+                    id: '0',
                     author: '212097368371683623',
                     content: '{fail}',
                     cooldown: 7
@@ -243,6 +249,7 @@ runSubtagTests({
                 ctx.options.inputRaw = 'This is some input text';
                 ctx.options.data = { stackSize: 100 };
                 ctx.ccommands['othersubtag'] = {
+                    id: '0',
                     author: '212097368371683623',
                     content: '{assert}{eval}',
                     cooldown: 7
@@ -288,6 +295,7 @@ runSubtagTests({
                 ctx.options.inputRaw = 'This is some input text';
                 ctx.options.data = { stackSize: 100 };
                 ctx.ccommands['othersubtag'] = {
+                    id: '0',
                     author: '212097368371683623',
                     content: '{assert}{eval}',
                     cooldown: 7
@@ -333,6 +341,7 @@ runSubtagTests({
                 ctx.options.inputRaw = 'This is some input text';
                 ctx.options.data = { stackSize: 100 };
                 ctx.ccommands['othersubtag'] = {
+                    id: '0',
                     author: '212097368371683623',
                     content: '{assert}{eval}',
                     cooldown: 7


### PR DESCRIPTION
Fixes [b!help sends nothing when there are too many commands](https://discord.com/channels/194232473931087872/1019673077086425151)

I added a character limit on command names to prevent them from breaking the help documentation. The names get put into the label field of the dropdowns, which discord limits to 100 characters.

The migration changes are designed to be expandable in the future, and to only ever be run once. I might restructure it later to be reusable for the other tables, but at the moment only the guild table needs it.
Theres no concerns about race conditions with the migrations as a cluster/master isnt classed as ready until the database is connected which includes the migrations having been run. To be safe, we should `restart kill` to deploy this codebase however.
