### PR TITLE
Disable `b!editcommand help` for convenience

### DIFF
--- a/src/cluster/dcommands/admin/editcommand.ts
+++ b/src/cluster/dcommands/admin/editcommand.ts
@@ -51,7 +51,7 @@ export class EditCommandCommand extends GuildCommand {
                     execute: (ctx, [commands]) => this.setHidden(ctx, commands.asStrings, false)
                 }
             ]
-        });
+        }, true);
     }
 
     public async list(context: GuildCommandContext): Promise<CommandResult> {


### PR DESCRIPTION
If editcommand has the hidden `help` subcommand, it makes it impossible to edit the help command, e.g. `b!editcommand help disable`

Fixes [Option to disable multiple commands at once broke?](https://discord.com/channels/194232473931087872/1024612610718564383)