### PR TITLE
Fix translations and add fake english translation

### DIFF
--- a/src/bbtag/text.ts
+++ b/src/bbtag/text.ts
@@ -365,7 +365,7 @@ Database Execution Time: {database#duration(MS)}ms
             description: 'If `moderator` is not provided or left empty, it will default to blargbot.',
             default: {
                 description: 'Creates a custom modLog entry with the given `action` and `user` with `reason`. `color` can be a [HTML color](https://www.w3schools.com/colors/colors_names.asp), hex, (r,g,b) or a valid color number. .',
-                exampleOut: 'You did a bad! (modLog entry with white embed colour and reason \'They did a bad!\'',
+                exampleOut: 'You did a bad! (modLog entry with white embed colour and reason \'They did a bad!\')',
                 exampleCode: 'You did a bad! \\{modLog;Bad;\\{userId\\};;They did a bad;#ffffff\\}'
             }
         },

--- a/src/cluster/dcommands/admin/settings.ts
+++ b/src/cluster/dcommands/admin/settings.ts
@@ -137,7 +137,7 @@ export class SettingsCommand extends GuildCommand {
 
     public languages(context: GuildCommandContext): CommandResult {
         const defined = [...FormatString.list()].map(s => s.id);
-        const locales = [];
+        const locales = [{ name: 'English', key: 'en', completion: 1 }];
         for (const [locale, details] of context.util.translator.languages) {
             let total = 0;
             for (const key of defined)
@@ -194,7 +194,7 @@ function resolveLanguage(language: string | undefined, translator: ITranslationS
     const details = translator.languages.get(language)
         ?? translator.languages.get(language = 'en');
     if (details === undefined)
-        return undefined;
+        return cmd.list.localeValue({ name: 'English', completion: 1 });
 
     let count = 0;
     let provided = 0;

--- a/src/cluster/text.ts
+++ b/src/cluster/text.ts
@@ -467,9 +467,9 @@ export const templates = FormatString.defineTree('cluster', t => ({
                         limit: {
                             name: {
                                 customCommandLimit: '**Limits for custom commands:**',
-                                everythingAutoResponseLimit: '**Limits for custom commands:**',
-                                generalAutoResponseLimit: '**Limits for custom commands:**',
-                                tagLimit: '**Limits for custom commands:**'
+                                everythingAutoResponseLimit: '**Limits for everything autoresponses:**',
+                                generalAutoResponseLimit: '**Limits for general autoresponses:**',
+                                tagLimit: '**Limits for tags:**'
                             },
                             value: t<{ rules: Iterable<IFormattable<string>>; }>('```\n{rules#join(\n)}\n```')
                         }
@@ -3068,9 +3068,9 @@ export const templates = FormatString.defineTree('cluster', t => ({
         warnings: {
             common: {
                 count: t<{ user: Eris.User; count: number; }>('{count#plural(0:🎉|⚠️)} **{user#tag}** {count#plural(0:doesn\'t have any warnings!|1:has accumulated 1 warning.|has accumulated {} warnings.)}'),
-                untilTimeout: t<{ remaining: number; }>('- {remaining} more warnings before being timed out.'),
-                untilKick: t<{ remaining: number; }>('- {remaining} more warnings before being kicked.'),
-                untilBan: t<{ remaining: number; }>('- {remaining} more warnings before being banned.'),
+                untilTimeout: t<{ remaining: number; }>('- {remaining} more {remaining#plural(1:warning|warnings)} before being timed out.'),
+                untilKick: t<{ remaining: number; }>('- {remaining} more {remaining#plural(1:warning|warnings)} before being being kicked.'),
+                untilBan: t<{ remaining: number; }>('- {remaining} more {remaining#plural(1:warning|warnings)} before being being banned.'),
                 success: t<{ parts: Iterable<IFormattable<string>>; }>('{parts#join(\n)}')
             },
             self: {

--- a/src/cluster/text.ts
+++ b/src/cluster/text.ts
@@ -3069,8 +3069,8 @@ export const templates = FormatString.defineTree('cluster', t => ({
             common: {
                 count: t<{ user: Eris.User; count: number; }>('{count#plural(0:🎉|⚠️)} **{user#tag}** {count#plural(0:doesn\'t have any warnings!|1:has accumulated 1 warning.|has accumulated {} warnings.)}'),
                 untilTimeout: t<{ remaining: number; }>('- {remaining} more {remaining#plural(1:warning|warnings)} before being timed out.'),
-                untilKick: t<{ remaining: number; }>('- {remaining} more {remaining#plural(1:warning|warnings)} before being being kicked.'),
-                untilBan: t<{ remaining: number; }>('- {remaining} more {remaining#plural(1:warning|warnings)} before being being banned.'),
+                untilKick: t<{ remaining: number; }>('- {remaining} more {remaining#plural(1:warning|warnings)} before being kicked.'),
+                untilBan: t<{ remaining: number; }>('- {remaining} more {remaining#plural(1:warning|warnings)} before being banned.'),
                 success: t<{ parts: Iterable<IFormattable<string>>; }>('{parts#join(\n)}')
             },
             self: {

--- a/src/crowdin/index.ts
+++ b/src/crowdin/index.ts
@@ -63,8 +63,13 @@ export class CrowdinTranslationSource implements ITranslationSource {
         }
 
         const lookup = new Map(strings);
-        this.#languageKeys.set(language.locale, { name: language.name, keys: new Set(lookup.keys()) });
-        this.#languageData.set(language.locale, lookup);
+        if (lookup.size === 0) {
+            this.#languageKeys.delete(language.locale);
+            this.#languageData.delete(language.locale);
+        } else {
+            this.#languageKeys.set(language.locale, { name: language.name, keys: new Set(lookup.keys()) });
+            this.#languageData.set(language.locale, lookup);
+        }
     }
 
     * #flattenJson(keys: string[], tree: CrowdinLanguageTree): Generator<[string, string]> {

--- a/test/bbtag/text.test.ts
+++ b/test/bbtag/text.test.ts
@@ -466,7 +466,7 @@ Database Execution Time: 678ms
                 description: 'If `moderator` is not provided or left empty, it will default to blargbot.',
                 default: {
                     description: 'Creates a custom modLog entry with the given `action` and `user` with `reason`. `color` can be a [HTML color](https://www.w3schools.com/colors/colors_names.asp), hex, (r,g,b) or a valid color number. .',
-                    exampleOut: 'You did a bad! (modLog entry with white embed colour and reason \'They did a bad!\'',
+                    exampleOut: 'You did a bad! (modLog entry with white embed colour and reason \'They did a bad!\')',
                     exampleCode: 'You did a bad! {modLog;Bad;{userId};;They did a bad;#ffffff}'
                 }
             },

--- a/test/cluster/text.test.ts
+++ b/test/cluster/text.test.ts
@@ -1472,9 +1472,9 @@ describe('Cluster format strings', () => {
                             limit: {
                                 name: {
                                     customCommandLimit: '**Limits for custom commands:**',
-                                    everythingAutoResponseLimit: '**Limits for custom commands:**',
-                                    generalAutoResponseLimit: '**Limits for custom commands:**',
-                                    tagLimit: '**Limits for custom commands:**'
+                                    everythingAutoResponseLimit: '**Limits for everything autoresponses:**',
+                                    generalAutoResponseLimit: '**Limits for general autoresponses:**',
+                                    tagLimit: '**Limits for tags:**'
                                 },
                                 value: [
                                     {
@@ -7651,21 +7651,36 @@ describe('Cluster format strings', () => {
                     ],
                     untilTimeout: [
                         {
-                            name: 'default',
+                            name: 'single',
+                            input: [{ remaining: 1 }],
+                            expected: '- 1 more warning before being timed out.'
+                        },
+                        {
+                            name: 'multiple',
                             input: [{ remaining: 123 }],
                             expected: '- 123 more warnings before being timed out.'
                         }
                     ],
                     untilKick: [
                         {
-                            name: 'default',
+                            name: 'single',
+                            input: [{ remaining: 1 }],
+                            expected: '- 1 more warning before being kicked.'
+                        },
+                        {
+                            name: 'multiple',
                             input: [{ remaining: 123 }],
                             expected: '- 123 more warnings before being kicked.'
                         }
                     ],
                     untilBan: [
                         {
-                            name: 'default',
+                            name: 'single',
+                            input: [{ remaining: 1 }],
+                            expected: '- 1 more warning before being banned.'
+                        },
+                        {
+                            name: 'multiple',
                             input: [{ remaining: 123 }],
                             expected: '- 123 more warnings before being banned.'
                         }


### PR DESCRIPTION
This just adds the en "translation" back to the listing, which represents the default text blarg will send