### PR TITLE
Use file not files

### DIFF
--- a/src/cluster/command/GlobalImageCommand.ts
+++ b/src/cluster/command/GlobalImageCommand.ts
@@ -32,7 +32,7 @@ export abstract class GlobalImageCommand extends GlobalCommand {
             return templates.commands.$errors.renderFailed;
 
         return {
-            files: [
+            file: [
                 {
                     file: result.data,
                     name: result.fileName

--- a/src/cluster/command/RawBBTagCommandResult.ts
+++ b/src/cluster/command/RawBBTagCommandResult.ts
@@ -30,7 +30,7 @@ export class RawBBTagCommandResult implements IFormattable<string | SendContent<
     #attach(formatter: IFormatter): SendContent<string> {
         return {
             content: this.#attached[format](formatter),
-            files: [
+            file: [
                 {
                     name: this.#fileName,
                     file: this.#content

--- a/src/cluster/dcommands/admin/ccommand.ts
+++ b/src/cluster/dcommands/admin/ccommand.ts
@@ -518,7 +518,7 @@ export class CustomCommandCommand extends GuildCommand {
 
         return {
             content: cmd.shrinkwrap.success,
-            files: [
+            file: [
                 {
                     file: JSON.stringify(<SignedGuildShrinkwrap>{
                         signature: signShrinkwrap(shrinkwrap, context.config),

--- a/src/cluster/dcommands/admin/logs.ts
+++ b/src/cluster/dcommands/admin/logs.ts
@@ -106,7 +106,7 @@ export class LogsCommand extends GuildCommand {
                 ? cmd.default.generated.json.slow({ user: context.author })
                 : cmd.default.generated.json.quick,
             allowedMentions: { users: [context.author.id] },
-            files: [
+            file: [
                 {
                     file: JSON.stringify(logs.map(l => ({ ...l, id: undefined })), null, 2),
                     name: `${channel.value.id}-logs.json`

--- a/src/cluster/dcommands/developer/i18n.ts
+++ b/src/cluster/dcommands/developer/i18n.ts
@@ -53,7 +53,7 @@ export class I18nCommand extends GlobalCommand {
         }
 
         return {
-            files: Object.entries(result)
+            file: Object.entries(result)
                 .map(([key, data]) => ({
                     file: JSON.stringify(data),
                     name: `${key}.json`

--- a/src/cluster/dcommands/developer/update.ts
+++ b/src/cluster/dcommands/developer/update.ts
@@ -72,8 +72,8 @@ export class UpdateCommand extends GlobalCommand {
                 name: 'output.txt'
             };
             message === undefined
-                ? await context.reply({ content, files: [file] })
-                : await context.edit(message, { content, files: [file] });
+                ? await context.reply({ content, file: [file] })
+                : await context.edit(message, { content, file: [file] });
             return result;
         } catch (err: unknown) {
             const content = cmd.default.command.error({ command });
@@ -83,8 +83,8 @@ export class UpdateCommand extends GlobalCommand {
                 name: 'output.txt'
             };
             message === undefined
-                ? await context.reply({ content, files: [file] })
-                : await context.edit(message, { content, files: [file] });
+                ? await context.reply({ content, file: [file] })
+                : await context.edit(message, { content, file: [file] });
             throw err;
         }
     }

--- a/src/cluster/dcommands/general/avatar.ts
+++ b/src/cluster/dcommands/general/avatar.ts
@@ -37,7 +37,7 @@ export class AvatarCommand extends GlobalCommand {
 
     public async getAvatar(user: User, format: string | undefined, size = '512'): Promise<CommandResult> {
         if (format !== undefined && !allowedFormats.includes(format))
-            return cmd.common.formatInvalid({format, allowedFormats});
+            return cmd.common.formatInvalid({ format, allowedFormats });
 
         const parsedSize = parse.int(size, { strict: true });
 
@@ -50,7 +50,7 @@ export class AvatarCommand extends GlobalCommand {
 
         return {
             content: cmd.common.success({ user }),
-            files: [{ file: await avatar.buffer(), name: new URL(avatarUrl).pathname.split('/').pop() ?? `${user.id}.${format ?? 'png'}` }]
+            file: [{ file: await avatar.buffer(), name: new URL(avatarUrl).pathname.split('/').pop() ?? `${user.id}.${format ?? 'png'}` }]
         };
     }
 }

--- a/src/cluster/dcommands/general/status.ts
+++ b/src/cluster/dcommands/general/status.ts
@@ -38,7 +38,7 @@ export class StatusCommand extends GlobalCommand {
         }
 
         return {
-            files: [
+            file: [
                 {
                     name: `${status}.jpg`,
                     file: content

--- a/src/cluster/dcommands/general/tag.ts
+++ b/src/cluster/dcommands/general/tag.ts
@@ -780,7 +780,7 @@ export class TagCommand extends GuildCommand {
                     }
                 }
             ],
-            files: [
+            file: [
                 ...'tag' in details && 'content' in details ? [{
                     name: `${details.tag}.bbtag`,
                     file: details.content

--- a/src/cluster/dcommands/image/cah.ts
+++ b/src/cluster/dcommands/image/cah.ts
@@ -62,7 +62,7 @@ export class CAHCommand extends GlobalImageCommand {
         const packNames = unofficial ? packs.all : packs.official;
         return {
             content: cmd.packs.success,
-            files: [
+            file: [
                 {
                     file: packNames.join('\n'),
                     name: 'cah-packs.txt'

--- a/src/cluster/dcommands/owner/exec.ts
+++ b/src/cluster/dcommands/owner/exec.ts
@@ -43,8 +43,8 @@ export class ExecCommand extends GlobalCommand {
                 name: 'output.txt'
             };
             message === undefined
-                ? await context.reply({ content, files: [file] })
-                : await context.edit(message, { content, files: [file] });
+                ? await context.reply({ content, file: [file] })
+                : await context.edit(message, { content, file: [file] });
         } catch (err: unknown) {
             const content = cmd.default.command.error({ command });
             const file = {
@@ -52,8 +52,8 @@ export class ExecCommand extends GlobalCommand {
                 name: 'output.txt'
             };
             message === undefined
-                ? await context.reply({ content, files: [file] })
-                : await context.edit(message, { content, files: [file] });
+                ? await context.reply({ content, file: [file] })
+                : await context.edit(message, { content, file: [file] });
         }
         return undefined;
     }

--- a/src/core/BaseUtilities.ts
+++ b/src/core/BaseUtilities.ts
@@ -115,7 +115,7 @@ export class BaseUtilities {
 
         const channel = await this.#getSendChannel(context);
         const formatter = await this.getFormatter(channel);
-        const { files = [], ...content } = payload[format](formatter);
+        const { file: files = [], ...content } = payload[format](formatter);
 
         // Stringifies embeds if we lack permissions to send embeds
         if (content.embeds !== undefined && guard.isGuildChannel(channel)) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -10,7 +10,7 @@ export type ModuleResult<TModule> = { names: Iterable<string>; module: TModule; 
 export type DMContext = string | KnownMessage | User | Member;
 export type SendContext = TextableChannel | string | User;
 export interface SendContent<TString> extends FormatAdvancedMessageContent<TString> {
-    files?: FileContent[];
+    file?: FileContent[];
 }
 
 type ReplaceProps<T, U extends { [P in keyof T]?: unknown }> = { [P in keyof T]: P extends keyof U ? U[P] : T[P] }

--- a/src/master/events/cluster/exit.ts
+++ b/src/master/events/cluster/exit.ts
@@ -21,7 +21,7 @@ export class ClusterExitHandler extends WorkerPoolEventService<ClusterConnection
             this.master.config.discord.channels.shardlog,
             new FormattableMessageContent({
                 content: util.literal(`Cluster ${worker.id} has died.`),
-                files: [{
+                file: [{
                     file: worker.logs.join('\n'),
                     name: `cluster ${worker.id}.log`
                 }]

--- a/src/master/services/ClusterMonitor.ts
+++ b/src/master/services/ClusterMonitor.ts
@@ -53,7 +53,7 @@ export class ClusterMonitor extends IntervalService {
                 this.master.config.discord.channels.shardlog,
                 new FormattableMessageContent({
                     content: util.literal(`Respawning unresponsive cluster ${cluster.id}...\n${issues.join('\n')}`),
-                    files: [{
+                    file: [{
                         file: cluster.logs.join('\n'),
                         name: `cluster ${cluster.id}.log`
                     }]


### PR DESCRIPTION
When sending files, blargbot strips off the `files` property because that is sent in a second parameter in eris. This is different for editing messages, where eris checks for a `file` property on the message payload. Dont ask why, its a bit nuts. This brings all of blargbot in line with eris, using the `file` property rather than `files`

Typing in eris:
![image](https://user-images.githubusercontent.com/7736591/199833047-814fe860-74d5-416a-a4d9-d382851c33bc.png)
![image](https://user-images.githubusercontent.com/7736591/199832926-bfdd59cd-5bdb-44e6-863e-cef9e126b79e.png)
