### PR TITLE
Add locale name from language definition

### DIFF
--- a/src/crowdin/index.ts
+++ b/src/crowdin/index.ts
@@ -67,7 +67,11 @@ export class CrowdinTranslationSource implements ITranslationSource {
             this.#languageKeys.delete(language.locale);
             this.#languageData.delete(language.locale);
         } else {
-            this.#languageKeys.set(language.locale, { name: language.name, keys: new Set(lookup.keys()) });
+            this.#languageKeys.set(language.locale, {
+                name: lookup.get('config.localeName') ?? language.name,
+                keys: new Set(lookup.keys())
+            });
+            lookup.delete('config.localeName');
             this.#languageData.set(language.locale, lookup);
         }
     }


### PR DESCRIPTION
Language names should be in the language its describing rather than english