### PR TITLE
Add command to dump all data blarg is holding

### DIFF
--- a/src/bbtag/getLock.ts
+++ b/src/bbtag/getLock.ts
@@ -1,8 +1,20 @@
 import { TagVariableScope, TagVariableType } from '@blargbot/domain/models';
 import ReadWriteLock from 'rwlock';
 
-const locks: Record<`${TagVariableType | ''}_${string}_${string}_${string}`, ReadWriteLock> = {};
+const locks: Record<string, ReadWriteLock | undefined> = {};
 
 export function getLock(scope: TagVariableScope | undefined, name: string): ReadWriteLock {
-    return locks[`${scope?.type ?? ''}_${scope?.entityId ?? ''}_${scope?.name ?? ''} _${name}`] ??= new ReadWriteLock();
+    return locks[getLockId(scope, name)] ??= new ReadWriteLock();
+}
+
+function getLockId(scope: TagVariableScope | undefined, name: string): string {
+    switch (scope?.type) {
+        case undefined: return `TEMP_${name}`;
+        case TagVariableType.AUTHOR: return `${scope.type}_${scope.authorId}_${name}`;
+        case TagVariableType.GLOBAL: return `${scope.type}_${name}`;
+        case TagVariableType.GUILD_CC: return `${scope.type}_${scope.guildId}_${name}`;
+        case TagVariableType.GUILD_TAG: return `${scope.type}_${scope.guildId}_${name}`;
+        case TagVariableType.LOCAL_CC: return `${scope.type}_${scope.guildId}_${scope.name}_${name}`;
+        case TagVariableType.LOCAL_TAG: return `${scope.type}_${scope.name}_${name}`;
+    }
 }

--- a/src/bbtag/subtags/user/userTimeZone.ts
+++ b/src/bbtag/subtags/user/userTimeZone.ts
@@ -45,7 +45,7 @@ export class UserTimezoneSubtag extends CompiledSubtag {
                 .withDisplay(quiet ? '' : undefined);
         }
 
-        const userTimezone = await context.database.users.getSetting(user.id, 'timezone');
+        const userTimezone = await context.database.users.getProp(user.id, 'timezone');
         return userTimezone ?? 'UTC';
     }
 }

--- a/src/bbtag/tagVariableScopeProviders.ts
+++ b/src/bbtag/tagVariableScopeProviders.ts
@@ -9,27 +9,23 @@ export const tagVariableScopeProviders: readonly TagVariableScopeProvider[] = [
         name: templates.subtag.variables.server.name,
         prefix: '_',
         description: templates.subtag.variables.server.description,
-        getScope: (context) => ({
-            type: context.tagVars ? TagVariableType.TAGGUILD : TagVariableType.GUILD,
-            entityId: context.guild.id
-        })
+        getScope: (context) => context.tagVars
+            ? { type: TagVariableType.GUILD_TAG, guildId: context.guild.id }
+            : { type: TagVariableType.GUILD_CC, guildId: context.guild.id }
     },
     {
         name: templates.subtag.variables.author.name,
         prefix: '@',
         description: templates.subtag.variables.author.description,
-        getScope: (context) => ({
-            type: TagVariableType.AUTHOR,
-            entityId: context.authorId
-        })
+        getScope: (context) => context.authorId !== undefined
+            ? { type: TagVariableType.AUTHOR, authorId: context.authorId }
+            : undefined
     },
     {
         name: templates.subtag.variables.global.name,
         prefix: '*',
         description: templates.subtag.variables.global.description,
-        getScope: () => ({
-            type: TagVariableType.GLOBAL
-        })
+        getScope: () => ({ type: TagVariableType.GLOBAL })
     },
     {
         name: templates.subtag.variables.temporary.name,
@@ -41,11 +37,9 @@ export const tagVariableScopeProviders: readonly TagVariableScopeProvider[] = [
         name: templates.subtag.variables.local.name,
         prefix: '',
         description: templates.subtag.variables.local.description,
-        getScope: (context) => ({
-            type: context.tagVars ? TagVariableType.LOCAL : TagVariableType.GUILDLOCAL,
-            entityId: context.tagVars ? undefined : context.guild.id,
-            name: context.rootTagName
-        })
+        getScope: (context) => context.tagVars
+            ? { type: TagVariableType.LOCAL_TAG, name: context.rootTagName }
+            : { type: TagVariableType.LOCAL_CC, name: context.rootTagName, guildId: context.guild.id }
     }
 ];
 

--- a/src/cluster/command/middleware/ErrorMiddleware.ts
+++ b/src/cluster/command/middleware/ErrorMiddleware.ts
@@ -16,7 +16,7 @@ export class ErrorMiddleware<TContext extends CommandContext> implements IMiddle
 
             if (err instanceof DiscordRESTError
                 && err.code === ApiError.MISSING_ACCESS
-                && await context.database.users.getSetting(context.author.id, 'dontdmerrors') !== true) {
+                && await context.database.users.getProp(context.author.id, 'dontdmerrors') !== true) {
                 const message = !guard.isGuildCommandContext(context)
                     ? templates.commands.$errors.missingPermission.generic
                     : templates.commands.$errors.missingPermission.guild(context);

--- a/src/cluster/dcommands/admin/bot.ts
+++ b/src/cluster/dcommands/admin/bot.ts
@@ -1,14 +1,14 @@
-import { TagVariableType } from '@blargbot/domain/models';
+import { StoredGuild, StoredUser, TagVariableType } from '@blargbot/domain/models';
 import { Constants } from 'eris';
 
-import { GuildCommand } from '../../command';
+import { CommandContext, GlobalCommand } from '../../command';
 import templates from '../../text';
-import { CommandResult, GuildCommandContext } from '../../types';
-import { CommandType } from '../../utils';
+import { CommandResult, GuildCommandContext, PrivateCommandContext } from '../../types';
+import { CommandType, guard } from '../../utils';
 
 const cmd = templates.commands.bot;
 
-export class ServerCommand extends GuildCommand {
+export class ServerCommand extends GlobalCommand {
     public constructor() {
         super({
             name: 'bot',
@@ -17,32 +17,189 @@ export class ServerCommand extends GuildCommand {
                 {
                     parameters: 'reset',
                     description: cmd.reset.description,
-                    execute: (ctx) => this.resetGuild(ctx)
+                    execute: (ctx) => this.reset(ctx)
+                },
+                {
+                    parameters: 'dump',
+                    description: cmd.dump.description,
+                    execute: (ctx) => this.dump(ctx)
                 }
             ]
         });
     }
 
-    public async resetGuild(context: GuildCommandContext): Promise<CommandResult> {
+    public async reset(context: CommandContext): Promise<CommandResult> {
+        if (guard.isGuildCommandContext(context))
+            return await this.#resetGuild(context);
+        else if (guard.isPrivateCommandContext(context))
+            return await this.#resetUser(context);
+        return cmd.reset.unavailable;
+    }
+
+    public async dump(context: CommandContext): Promise<CommandResult> {
+        if (guard.isGuildCommandContext(context))
+            return await this.#dumpGuild(context);
+        else if (guard.isPrivateCommandContext(context))
+            return await this.#dumpUser(context);
+        return cmd.dump.unavailable;
+    }
+
+    async #resetGuild(context: GuildCommandContext): Promise<CommandResult> {
+        const text = cmd.reset.guild;
         if (await context.queryConfirm({
-            prompt: cmd.reset.confirm.prompt,
+            prompt: text.confirm.prompt,
             cancel: {
                 style: Constants.ButtonStyles.SECONDARY,
-                label: cmd.reset.confirm.cancel
+                label: text.confirm.cancel
             },
             continue: {
                 style: Constants.ButtonStyles.DANGER,
-                label: cmd.reset.confirm.continue
+                label: text.confirm.continue
             }
         }) !== true) {
-            return cmd.reset.cancelled;
+            return text.cancelled;
         }
 
         await context.database.guilds.reset(context.channel.guild);
-        await context.database.tagVariables.clearScope({ type: TagVariableType.GUILD, entityId: context.channel.guild.id });
-        await context.database.tagVariables.clearScope({ type: TagVariableType.TAGGUILD, entityId: context.channel.guild.id });
-        await context.database.tagVariables.clearScope({ type: TagVariableType.GUILDLOCAL, entityId: context.channel.guild.id });
+        await context.database.tagVariables.clearScope({ type: TagVariableType.GUILD_CC, guildId: context.channel.guild.id });
+        await context.database.tagVariables.clearScope({ type: TagVariableType.GUILD_TAG, guildId: context.channel.guild.id });
+        await context.database.tagVariables.clearScope({ type: TagVariableType.LOCAL_CC, guildId: context.channel.guild.id });
 
-        return cmd.reset.success;
+        return text.success;
+    }
+
+    async #resetUser(context: PrivateCommandContext): Promise<CommandResult> {
+        const text = cmd.reset.user;
+        if (await context.queryConfirm({
+            prompt: text.confirm.prompt,
+            cancel: {
+                style: Constants.ButtonStyles.SECONDARY,
+                label: text.confirm.cancel
+            },
+            continue: {
+                style: Constants.ButtonStyles.DANGER,
+                label: text.confirm.continue
+            }
+        }) !== true) {
+            return text.cancelled;
+        }
+
+        const tags = await context.database.tags.byAuthor(context.author.id);
+        await context.database.users.reset(context.author);
+        await context.database.tags.deleteByAuthor(context.author.id);
+        await context.database.tagVariables.clearScope({ type: TagVariableType.AUTHOR, authorId: context.author.id });
+        await context.database.tagVariables.clearScope({ type: TagVariableType.LOCAL_TAG, name: tags });
+        return text.success;
+    }
+
+    async #dumpGuild(context: GuildCommandContext): Promise<CommandResult> {
+        if (await context.queryConfirm({
+            prompt: cmd.dump.confirm.prompt,
+            cancel: {
+                style: Constants.ButtonStyles.SECONDARY,
+                label: cmd.dump.confirm.cancel
+            },
+            continue: {
+                style: Constants.ButtonStyles.DANGER,
+                label: cmd.dump.confirm.continue
+            }
+        }) !== true) {
+            return cmd.dump.cancelled;
+        }
+        const [guild, ...variables] = await Promise.all([
+            context.database.guilds.get(context.channel.guild.id),
+            context.database.tagVariables.getScope({ type: TagVariableType.GUILD_CC, guildId: context.channel.guild.id }),
+            context.database.tagVariables.getScope({ type: TagVariableType.GUILD_TAG, guildId: context.channel.guild.id }),
+            context.database.tagVariables.getScope({ type: TagVariableType.LOCAL_CC, guildId: context.channel.guild.id })
+        ]);
+
+        return {
+            content: cmd.dump.success,
+            file: [{
+                name: `GUILD_${context.channel.guild.id}.dump.json`,
+                file: JSON.stringify({
+                    ...pickOrNull(guild, ...guildKeys),
+                    variables: variables.flat()
+                })
+            }]
+        };
+    }
+
+    async #dumpUser(context: PrivateCommandContext): Promise<CommandResult> {
+        const userPromise = context.database.users.get(context.author.id);
+        const tagsPromise = context.database.tags.getAllByAuthor(context.author.id);
+        const authorVarsPromise = context.database.tagVariables.getScope({ type: TagVariableType.AUTHOR, authorId: context.author.id });
+
+        const tags = await tagsPromise;
+        const [user, ...variables] = await Promise.all([
+            userPromise,
+            authorVarsPromise,
+            context.database.tagVariables.getScope({ type: TagVariableType.LOCAL_TAG, name: tags.map(t => t.name) })
+        ]);
+
+        return {
+            content: cmd.dump.success,
+            file: [{
+                name: `USER_${context.author.id}.dump.json`,
+                file: JSON.stringify({
+                    ...pickOrNull(user, ...userKeys),
+                    variables: variables.flat(),
+                    tags
+                })
+            }]
+        };
+
     }
 }
+
+function pickOrNull<Source extends object, Key extends keyof Source>(source: Source | undefined, ...keys: Key[]): Pick<{ [P in keyof Source]: Source[P] | null }, Key> | undefined {
+    if (source === undefined)
+        return undefined;
+    return Object.fromEntries(keys.map(k => [k, source[k] as unknown ?? null] as const)) as ReturnType<typeof pickOrNull<Source, Key>>;
+}
+
+function selectKeys<T extends object>(values: { [P in keyof T]-?: boolean }): Array<keyof T> {
+    return Object.entries(values).filter(e => e[1]).map(e => e[0]);
+}
+
+const userKeys = selectKeys<StoredUser>({
+    todo: true,
+    dontdmerrors: true,
+    prefixes: true,
+    timezone: true,
+    usernames: true,
+
+    // Not dumped
+    avatarURL: false,
+    blacklisted: false,
+    discriminator: false,
+    reportblock: false,
+    reports: false,
+    userid: false,
+    username: false
+});
+
+const guildKeys = selectKeys<StoredGuild>({
+    announce: true,
+    autoresponse: true,
+    ccommands: true,
+    censor: true,
+    channels: true,
+    commandperms: true,
+    farewell: true,
+    greeting: true,
+    interval: true,
+    log: true,
+    logIgnore: true,
+    modlog: true,
+    roleme: true,
+    settings: true,
+    votebans: true,
+    warnings: true,
+
+    // Not dumped
+    active: false,
+    guildid: false,
+    name: false,
+    nextModlogId: false
+});

--- a/src/cluster/dcommands/general/dmerrors.ts
+++ b/src/cluster/dcommands/general/dmerrors.ts
@@ -22,8 +22,8 @@ export class DMErrorsCommand extends GlobalCommand {
     }
 
     public async toggleDMErrors(context: CommandContext): Promise<CommandResult> {
-        const dmErrors = !(await context.database.users.getSetting(context.author.id, 'dontdmerrors') ?? false);
-        await context.database.users.setSetting(context.author.id, 'dontdmerrors', dmErrors);
+        const dmErrors = !(await context.database.users.getProp(context.author.id, 'dontdmerrors') ?? false);
+        await context.database.users.setProp(context.author.id, 'dontdmerrors', dmErrors);
 
         return dmErrors
             ? cmd.default.enabled

--- a/src/cluster/dcommands/general/personalprefix.ts
+++ b/src/cluster/dcommands/general/personalprefix.ts
@@ -33,7 +33,7 @@ export class PersonalPrefixCommand extends GlobalCommand {
     }
 
     public async listPrefixes(context: CommandContext): Promise<CommandResult> {
-        const prefixes = await context.database.users.getSetting(context.author.id, 'prefixes');
+        const prefixes = await context.database.users.getProp(context.author.id, 'prefixes');
         if (prefixes === undefined || prefixes.length === 0)
             return cmd.list.none;
 

--- a/src/cluster/dcommands/general/time.ts
+++ b/src/cluster/dcommands/general/time.ts
@@ -39,7 +39,7 @@ export class TimeCommand extends GlobalCommand {
     }
 
     public async getUserTime(context: CommandContext, user: User): Promise<CommandResult> {
-        const timezone = await context.database.users.getSetting(user.id, 'timezone');
+        const timezone = await context.database.users.getProp(user.id, 'timezone');
         if (timezone === undefined)
             return cmd.user.timezoneNotSet({ prefix: context.prefix, user });
 

--- a/src/cluster/dcommands/general/timezone.ts
+++ b/src/cluster/dcommands/general/timezone.ts
@@ -29,7 +29,7 @@ export class TimezoneCommand extends GlobalCommand {
     }
 
     public async getTimezone(context: CommandContext, user: User): Promise<CommandResult> {
-        const timezone = await context.database.users.getSetting(user.id, 'timezone');
+        const timezone = await context.database.users.getProp(user.id, 'timezone');
         if (timezone === undefined)
             return cmd.get.notSet;
 
@@ -45,7 +45,7 @@ export class TimezoneCommand extends GlobalCommand {
         if (now.zoneAbbr() === '')
             return cmd.set.timezoneInvalid({ timezone });
 
-        await context.database.users.setSetting(user.id, 'timezone', timezone);
+        await context.database.users.setProp(user.id, 'timezone', timezone);
         return cmd.set.success({ timezone, now });
     }
 }

--- a/src/cluster/managers/PrefixManager.ts
+++ b/src/cluster/managers/PrefixManager.ts
@@ -41,7 +41,7 @@ export class PrefixManager {
     }
 
     public async getUserPrefixes(userId: string): Promise<readonly string[]> {
-        return await this.#users.getSetting(userId, 'prefixes') ?? [];
+        return await this.#users.getProp(userId, 'prefixes') ?? [];
     }
 
     public async addUserPrefix(userId: string, prefix: string): Promise<boolean> {
@@ -49,7 +49,7 @@ export class PrefixManager {
         if (prefixes.size === prefixes.add(prefix.toLowerCase()).size)
             return false;
 
-        return await this.#users.setSetting(userId, 'prefixes', [...prefixes]);
+        return await this.#users.setProp(userId, 'prefixes', [...prefixes]);
     }
 
     public async removeUserPrefix(userId: string, prefix: string): Promise<boolean> {
@@ -57,7 +57,7 @@ export class PrefixManager {
         if (prefixes.delete(prefix.toLowerCase()))
             return false;
 
-        return await this.#users.setSetting(userId, 'prefixes', [...prefixes]);
+        return await this.#users.setProp(userId, 'prefixes', [...prefixes]);
     }
 
     public async findPrefix(message: KnownMessage): Promise<string | undefined> {

--- a/src/cluster/managers/commands/CommandManager.ts
+++ b/src/cluster/managers/commands/CommandManager.ts
@@ -52,7 +52,7 @@ export abstract class CommandManager<T> implements ICommandManager<T> {
         if (this.cluster.util.isBotOwner(user.id))
             return { state: 'ALLOWED' };
 
-        const blacklistReason = await this.cluster.database.users.getSetting(user.id, 'blacklisted');
+        const blacklistReason = await this.cluster.database.users.getProp(user.id, 'blacklisted');
         if (blacklistReason !== undefined)
             return { state: 'BLACKLISTED', detail: blacklistReason };
 

--- a/src/cluster/text.ts
+++ b/src/cluster/text.ts
@@ -927,13 +927,36 @@ export const templates = FormatString.defineTree('cluster', t => ({
         },
         bot: {
             reset: {
-                description: 'Resets the bot to the state it is in when joining a guild for the first time.',
-                cancelled: '❌ Reset cancelled',
-                success: '✅ I have been reset back to my initial configuration',
+                description: 'Deletes all persistent information that the bot holds. If used in a guild, this includes settings, custom commands and guild variables. If used in a DM this includes user settings, tags and author variables. You can preview exactly what will be deleted by doing `bot dump` first!',
+                unavailable: 'The bot cannot be reset here',
+                guild: {
+                    cancelled: '❌ Reset cancelled',
+                    success: '✅ I have been reset back to my initial configuration',
+                    confirm: {
+                        prompt: '⚠️ Are you sure you want to reset the bot to its initial state?\nThis will:\n- Reset all settings back to their defaults\n- Delete all custom commands, autoresponses, rolemes, censors, etc\n- Delete all tag guild variables',
+                        cancel: 'No',
+                        continue: 'Yes'
+                    }
+                },
+                user: {
+                    cancelled: '❌ Reset cancelled',
+                    success: '✅ I have been reset back to my initial configuration',
+                    confirm: {
+                        prompt: '⚠️ Are you sure you want to reset the bot to its initial state?\nThis will:\n- Reset all your user settings back to their defaults\n- Delete all tags you have made\n- Delete all author variables',
+                        cancel: 'No',
+                        continue: 'Yes'
+                    }
+                }
+            },
+            dump: {
+                description: 'Dumps all persistent information that the bot holds. If used',
+                unavailable: 'The bot cannot be reset here',
+                success: '✅ I have attached the data you requested!',
+                cancelled: '❌ Dump cancelled',
                 confirm: {
-                    prompt: '⚠️ Are you sure you want to reset the bot to its initial state?\nThis will:\n- Reset all settings back to their defaults\n- Delete all custom commands, autoresponses, rolemes, censors, etc\n- Delete all tag guild variables',
-                    cancel: 'No',
-                    continue: 'Yes'
+                    prompt: '⚠️ Are you sure you want to dump all the information blargbot is holding? This could include some sensitive information, so ensure that it is ok for everyone here to see it.',
+                    cancel: 'Cancel',
+                    continue: 'Show me that data'
                 }
             }
         },

--- a/src/database/stores/PostgresDbTagVariableStore.ts
+++ b/src/database/stores/PostgresDbTagVariableStore.ts
@@ -21,7 +21,7 @@ export class PostgresDbTagVariableStore implements TagVariableStore {
                 allowNull: false
             },
             type: {
-                type: ENUM(...variableTypes),
+                type: ENUM(...Object.values(TagVariableType)),
                 primaryKey: true,
                 allowNull: false
             },
@@ -101,15 +101,6 @@ function deserialize(value: string): JToken {
         return value;
     }
 }
-
-const variableTypes = Object.keys<TagVariableType>({
-    AUTHOR: null,
-    GLOBAL: null,
-    GUILD_CC: null,
-    GUILD_TAG: null,
-    LOCAL_CC: null,
-    LOCAL_TAG: null
-});
 
 function variableScopeToId(scope: TagVariableScope): string {
     switch (scope.type) {

--- a/src/database/tables/PostgresDbTable.ts
+++ b/src/database/tables/PostgresDbTable.ts
@@ -14,6 +14,11 @@ export class PostgresDbTable<T extends object> {
         return model?.get();
     }
 
+    public async getAll(filter: FindOptions<T>): Promise<T[]> {
+        const models = await this.#model.findAll(filter);
+        return models.map(m => m.get());
+    }
+
     public async destroy(filter: FindOptions<T>): Promise<void> {
         await this.#model.destroy(filter);
     }

--- a/src/domain/models/tagVariables/TagVariableScope.ts
+++ b/src/domain/models/tagVariables/TagVariableScope.ts
@@ -1,7 +1,47 @@
 import { TagVariableType } from './TagVariableType';
 
-export interface TagVariableScope {
-    readonly type: TagVariableType;
-    readonly entityId?: string;
-    readonly name?: string;
+export type TagVariableScope =
+    | GuildCCVariableScope
+    | GuildTagVariableScope
+    | AuthorVariableScope
+    | GlobalVariableScope
+    | LocalCCVariableScope
+    | LocalTagVariableScope
+
+export type TagVariableScopeFilter = {
+    [T in TagVariableScope as T['type']]: ToTagVariableScopeFilter<T>;
+}[TagVariableScope['type']]
+
+type ToTagVariableScopeFilter<T extends TagVariableScope> =
+    & { readonly type: T['type']; }
+    & { [P in Exclude<keyof T, 'type'>]?: T[P] | ReadonlyArray<T[P]> }
+
+export interface GuildCCVariableScope {
+    readonly type: TagVariableType.GUILD_CC;
+    readonly guildId: string;
+}
+
+export interface GuildTagVariableScope {
+    readonly type: TagVariableType.GUILD_TAG;
+    readonly guildId: string;
+}
+
+export interface AuthorVariableScope {
+    readonly type: TagVariableType.AUTHOR;
+    readonly authorId: string;
+}
+
+export interface GlobalVariableScope {
+    readonly type: TagVariableType.GLOBAL;
+}
+
+export interface LocalTagVariableScope {
+    readonly type: TagVariableType.LOCAL_TAG;
+    readonly name: string;
+}
+
+export interface LocalCCVariableScope {
+    readonly type: TagVariableType.LOCAL_CC;
+    readonly guildId: string;
+    readonly name: string;
 }

--- a/src/domain/models/tagVariables/TagVariableType.ts
+++ b/src/domain/models/tagVariables/TagVariableType.ts
@@ -1,8 +1,8 @@
 export enum TagVariableType {
-    LOCAL = 'LOCAL_TAG',
     AUTHOR = 'AUTHOR',
-    GUILD = 'GUILD_CC',
     GLOBAL = 'GLOBAL',
-    TAGGUILD = 'GUILD_TAG',
-    GUILDLOCAL = 'LOCAL_CC'
+    GUILD_CC = 'GUILD_CC',
+    GUILD_TAG = 'GUILD_TAG',
+    LOCAL_TAG = 'LOCAL_TAG',
+    LOCAL_CC = 'LOCAL_CC'
 }

--- a/src/domain/models/users/ResettableStoredUserData.ts
+++ b/src/domain/models/users/ResettableStoredUserData.ts
@@ -1,0 +1,8 @@
+import { UserTodo } from './UserTodo';
+
+export interface ResettableStoredUserData {
+    readonly todo: readonly UserTodo[];
+    readonly dontdmerrors?: boolean;
+    readonly prefixes?: readonly string[];
+    readonly timezone?: string;
+}

--- a/src/domain/models/users/StoredUser.ts
+++ b/src/domain/models/users/StoredUser.ts
@@ -1,18 +1,13 @@
+import { ResettableStoredUserData } from './ResettableStoredUserData';
 import { StoredUsername } from './StoredUsername';
-import { StoredUserSettings } from './StoredUserSettings';
-import { UserTodo } from './UserTodo';
 
-export interface StoredUser extends StoredUserSettings {
+export interface StoredUser extends ResettableStoredUserData {
     readonly userid: string;
+    readonly reportblock?: string;
+    readonly blacklisted?: string;
+    readonly reports?: { readonly [key: string]: string | undefined; };
     readonly username?: string;
     readonly usernames: readonly StoredUsername[];
     readonly discriminator?: string;
     readonly avatarURL?: string;
-    readonly isbot: boolean;
-    readonly lastspoke: Date;
-    readonly lastcommand?: string;
-    readonly lastcommanddate?: Date;
-    readonly todo: readonly UserTodo[];
-    readonly reportblock?: string;
-    readonly reports?: { readonly [key: string]: string | undefined; };
 }

--- a/src/domain/models/users/StoredUserSettings.ts
+++ b/src/domain/models/users/StoredUserSettings.ts
@@ -1,6 +1,0 @@
-export interface StoredUserSettings {
-    readonly dontdmerrors?: boolean;
-    readonly prefixes?: readonly string[];
-    readonly blacklisted?: string;
-    readonly timezone?: string;
-}

--- a/src/domain/models/users/index.ts
+++ b/src/domain/models/users/index.ts
@@ -1,5 +1,5 @@
 export * from './StoredUser';
 export * from './StoredUsername';
-export * from './StoredUserSettings';
+export * from './ResettableStoredUserData';
 export * from './UserDetails';
 export * from './UserTodo';

--- a/src/domain/stores/TagStore.ts
+++ b/src/domain/stores/TagStore.ts
@@ -3,14 +3,17 @@ import { StoredTag } from '../models';
 export interface TagStore {
     list(skip: number, take: number): Promise<readonly string[]>;
     count(): Promise<number>;
+    byAuthor(userId: string): Promise<readonly string[]>;
     byAuthor(userId: string, skip: number, take: number): Promise<readonly string[]>;
     byAuthorCount(userId: string): Promise<number>;
     search(partialName: string, skip: number, take: number): Promise<readonly string[]>;
     searchCount(partialName: string): Promise<number>;
     delete(name: string): Promise<boolean>;
+    deleteByAuthor(author: string): Promise<boolean>;
     disable(tagName: string, userId: string, reason: string): Promise<boolean>;
     top(count: number): Promise<readonly StoredTag[]>;
     get(tagName: string): Promise<StoredTag | undefined>;
+    getAllByAuthor(authorId: string): Promise<readonly StoredTag[]>;
     set(tag: StoredTag): Promise<boolean>;
     update(tagName: string, tag: Partial<StoredTag>): Promise<boolean>;
     setProp<K extends keyof StoredTag>(tagName: string, key: K, value: StoredTag[K]): Promise<boolean>;

--- a/src/domain/stores/TagVariableStore.ts
+++ b/src/domain/stores/TagVariableStore.ts
@@ -1,7 +1,8 @@
-import { TagVariableScope } from '../models';
+import { TagVariableScope, TagVariableScopeFilter } from '../models';
 
 export interface TagVariableStore {
     upsert(values: Record<string, JToken | undefined>, scope: TagVariableScope): Promise<void>;
     get(name: string, scope: TagVariableScope): Promise<JToken | undefined>;
-    clearScope(scope: TagVariableScope): Promise<void>;
+    getScope(scope: TagVariableScopeFilter): Promise<Array<{ scope: TagVariableScope; name: string; value: JToken; }>>;
+    clearScope(scope: TagVariableScopeFilter): Promise<void>;
 }

--- a/src/domain/stores/UserStore.ts
+++ b/src/domain/stores/UserStore.ts
@@ -1,4 +1,4 @@
-import { StoredUser, StoredUsername, StoredUserSettings, UserDetails } from '../models';
+import { StoredUser, StoredUsername, UserDetails } from '../models';
 
 export interface UserStore {
     getTodo(userId: string, skipCache?: boolean): Promise<readonly string[] | undefined>;
@@ -8,9 +8,10 @@ export interface UserStore {
     removePrefix(userId: string, prefix: string): Promise<boolean>;
     removeUsernames(userId: string, usernames: readonly string[] | 'all'): Promise<boolean>;
     getUsernames(userId: string, skipCache?: boolean): Promise<readonly StoredUsername[] | undefined>;
-    setSetting<K extends keyof StoredUserSettings>(userId: string, key: K, value: StoredUserSettings[K]): Promise<boolean>;
-    getSetting<K extends keyof StoredUserSettings>(userId: string, key: K, skipCache?: boolean): Promise<StoredUserSettings[K] | undefined>;
+    setProp<K extends keyof StoredUser>(userId: string, key: K, value: StoredUser[K]): Promise<boolean>;
+    getProp<K extends keyof StoredUser>(userId: string, key: K, skipCache?: boolean): Promise<StoredUser[K] | undefined>;
     get(userId: string, skipCache?: boolean): Promise<StoredUser | undefined>;
+    reset(user: UserDetails): Promise<'inserted' | 'updated' | false>;
     upsert(user: UserDetails): Promise<'inserted' | 'updated' | false>;
     setTagReport(userId: string, tagName: string, reason: string | undefined): Promise<boolean>;
 }

--- a/test/bbtag/subtags/array/concat.test.ts
+++ b/test/bbtag/subtags/array/concat.test.ts
@@ -16,8 +16,8 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr2`] = ['this', 'is', 'arr2'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr2' }, ['this', 'is', 'arr2']);
             }
         }
     ]

--- a/test/bbtag/subtags/array/filter.test.ts
+++ b/test/bbtag/subtags/array/filter.test.ts
@@ -26,15 +26,15 @@ runSubtagTests({
             subtags: [new GetSubtag(), new OperatorSubtag(), new LengthSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'filter:loops')).verifiable(3).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -43,15 +43,15 @@ runSubtagTests({
             subtags: [new GetSubtag(), new OperatorSubtag(), new LengthSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'filter:loops')).verifiable(3).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -60,15 +60,15 @@ runSubtagTests({
             subtags: [new GetSubtag(), new OperatorSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'filter:loops')).verifiable(12).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -77,15 +77,15 @@ runSubtagTests({
             subtags: [new GetSubtag(), new OperatorSubtag(), new CommentSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'filter:loops')).verifiable(12).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -94,15 +94,15 @@ runSubtagTests({
             subtags: [new GetSubtag(), new OperatorSubtag(), new CommentSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'filter:loops')).verifiable(12).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -111,15 +111,15 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IfSubtag(), new ReturnSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'filter:loops')).verifiable(4).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
                 expect(bbctx.data.state).to.equal(BBTagRuntimeState.ABORT);
             }
         },
@@ -132,8 +132,8 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 let i = 0;
@@ -145,7 +145,7 @@ runSubtagTests({
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         }
     ]

--- a/test/bbtag/subtags/array/isArray.test.ts
+++ b/test/bbtag/subtags/array/isArray.test.ts
@@ -19,7 +19,7 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             }
         }
     ]

--- a/test/bbtag/subtags/array/join.test.ts
+++ b/test/bbtag/subtags/array/join.test.ts
@@ -24,7 +24,7 @@ runSubtagTests({
             expected: 'this~is~arr1',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             }
         },
         {
@@ -35,7 +35,7 @@ runSubtagTests({
             ],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'This is var1';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'This is var1');
             }
         },
         {
@@ -44,7 +44,7 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             }
         }
     ]

--- a/test/bbtag/subtags/array/map.test.ts
+++ b/test/bbtag/subtags/array/map.test.ts
@@ -23,15 +23,15 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'map:loops')).verifiable(3).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -40,15 +40,15 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'map:loops')).verifiable(3).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -57,15 +57,15 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'map:loops')).verifiable(12).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -74,15 +74,15 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IfSubtag(), new ReturnSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'map:loops')).verifiable(4).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
                 expect(bbctx.data.state).to.equal(BBTagRuntimeState.ABORT);
             }
         },
@@ -95,8 +95,8 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 let i = 0;
@@ -108,7 +108,7 @@ runSubtagTests({
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         }
     ]

--- a/test/bbtag/subtags/array/pop.test.ts
+++ b/test/bbtag/subtags/array/pop.test.ts
@@ -26,7 +26,7 @@ runSubtagTests({
             ],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
             }
         },
         {
@@ -40,10 +40,10 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal(['this', 'is', 'arr1']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal(['this', 'is', 'arr1']);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['this', 'is']);
             }
         },
@@ -54,10 +54,10 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal(['this', 'is', 'arr1']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal(['this', 'is', 'arr1']);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['this', 'is']);
             }
         },
@@ -68,8 +68,8 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ arr1: ['this', 'is'] }), argument.isDeepEqual({ type: TagVariableType.LOCAL, name: 'testTag' }))).thenResolve(undefined);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ arr1: ['this', 'is'] }), argument.isDeepEqual({ type: TagVariableType.LOCAL_TAG, name: 'testTag' }))).thenResolve(undefined);
             },
             async assert(bbctx) {
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['this', 'is']);

--- a/test/bbtag/subtags/array/push.test.ts
+++ b/test/bbtag/subtags/array/push.test.ts
@@ -26,7 +26,7 @@ runSubtagTests({
             ],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
             }
         },
         {
@@ -40,10 +40,10 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal(['this', 'is', 'arr1']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal(['this', 'is', 'arr1']);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['this', 'is', 'arr1', 'def']);
             }
         },
@@ -54,10 +54,10 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal(['this', 'is', 'arr1']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal(['this', 'is', 'arr1']);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['this', 'is', 'arr1', 'def']);
             }
         },
@@ -68,8 +68,8 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ arr1: ['this', 'is', 'arr1', 'def'] }), argument.isDeepEqual({ type: TagVariableType.LOCAL, name: 'testTag' }))).thenResolve(undefined);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ arr1: ['this', 'is', 'arr1', 'def'] }), argument.isDeepEqual({ type: TagVariableType.LOCAL_TAG, name: 'testTag' }))).thenResolve(undefined);
             },
             async assert(bbctx) {
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['this', 'is', 'arr1', 'def']);

--- a/test/bbtag/subtags/array/shift.test.ts
+++ b/test/bbtag/subtags/array/shift.test.ts
@@ -26,7 +26,7 @@ runSubtagTests({
             ],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
             }
         },
         {
@@ -40,10 +40,10 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal(['this', 'is', 'arr1']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal(['this', 'is', 'arr1']);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['is', 'arr1']);
             }
         },
@@ -54,10 +54,10 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal(['this', 'is', 'arr1']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal(['this', 'is', 'arr1']);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['is', 'arr1']);
             }
         },
@@ -68,8 +68,8 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ arr1: ['is', 'arr1'] }), argument.isDeepEqual({ type: TagVariableType.LOCAL, name: 'testTag' }))).thenResolve(undefined);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ arr1: ['is', 'arr1'] }), argument.isDeepEqual({ type: TagVariableType.LOCAL_TAG, name: 'testTag' }))).thenResolve(undefined);
             },
             async assert(bbctx) {
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['is', 'arr1']);

--- a/test/bbtag/subtags/array/shuffle.test.ts
+++ b/test/bbtag/subtags/array/shuffle.test.ts
@@ -37,7 +37,7 @@ runSubtagTests({
             ],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
             }
         },
         {
@@ -57,10 +57,10 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 3, 4, 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 3, 4, 5, 6]);
                 const result = (await bbctx.variables.get('arr1')).value;
                 expect(result).to.not.deep.equal([1, 2, 3, 4, 5, 6]);
                 expect(result).to.have.members([1, 2, 3, 4, 5, 6]);

--- a/test/bbtag/subtags/array/slice.test.ts
+++ b/test/bbtag/subtags/array/slice.test.ts
@@ -51,10 +51,10 @@ runSubtagTests({
             expected: '[2,3,4]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4]);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 3, 4]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 3, 4]);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal([1, 2, 3, 4]);
             }
         },
@@ -63,10 +63,10 @@ runSubtagTests({
             expected: '[2,3]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4]);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 3, 4]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 3, 4]);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal([1, 2, 3, 4]);
             }
         }

--- a/test/bbtag/subtags/array/sort.test.ts
+++ b/test/bbtag/subtags/array/sort.test.ts
@@ -50,10 +50,10 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal(['this', 'is', 'arr1']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal(['this', 'is', 'arr1']);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['arr1', 'is', 'this']);
             }
         },
@@ -64,10 +64,10 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
             },
             async assert(bbctx, _, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal(['this', 'is', 'arr1']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal(['this', 'is', 'arr1']);
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['arr1', 'is', 'this']);
             }
         },
@@ -78,8 +78,8 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ arr1: ['arr1', 'is', 'this'] }), argument.isDeepEqual({ type: TagVariableType.LOCAL, name: 'testTag' }))).thenResolve(undefined);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ arr1: ['arr1', 'is', 'this'] }), argument.isDeepEqual({ type: TagVariableType.LOCAL_TAG, name: 'testTag' }))).thenResolve(undefined);
             },
             async assert(bbctx) {
                 expect((await bbctx.variables.get('arr1')).value).to.deep.equal(['arr1', 'is', 'this']);

--- a/test/bbtag/subtags/array/splice.test.ts
+++ b/test/bbtag/subtags/array/splice.test.ts
@@ -15,10 +15,10 @@ runSubtagTests({
             expected: '[]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 3, 4, 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 3, 4, 5, 6]);
             }
         },
         {
@@ -26,10 +26,10 @@ runSubtagTests({
             expected: '[]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 3, 4, 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 3, 4, 5, 6]);
             }
         },
         {
@@ -37,10 +37,10 @@ runSubtagTests({
             expected: '[3]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 4, 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 4, 5, 6]);
             }
         },
         {
@@ -48,10 +48,10 @@ runSubtagTests({
             expected: '[2,3,4]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 5, 6]);
             }
         },
         {
@@ -59,10 +59,10 @@ runSubtagTests({
             expected: '[5,6]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 3, 4]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 3, 4]);
             }
         },
         {
@@ -70,10 +70,10 @@ runSubtagTests({
             expected: '[]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 'a', 3, 4, 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 'a', 3, 4, 5, 6]);
             }
         },
         {
@@ -81,10 +81,10 @@ runSubtagTests({
             expected: '[3]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 'a', 4, 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 'a', 4, 5, 6]);
             }
         },
         {
@@ -92,10 +92,10 @@ runSubtagTests({
             expected: '[3,4]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 'a', 'b', 'c', 'd', 'e', 'f', 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 'a', 'b', 'c', 'd', 'e', 'f', 5, 6]);
             }
         },
         {
@@ -103,10 +103,10 @@ runSubtagTests({
             expected: '[3,4]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 'a', '1', '2', 'd', 'e', 'f', 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 'a', '1', '2', 'd', 'e', 'f', 5, 6]);
             }
         },
         {
@@ -114,10 +114,10 @@ runSubtagTests({
             expected: '[3,4]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 'a', 1, 2, 'd', 'e', 'f', 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 'a', 1, 2, 'd', 'e', 'f', 5, 6]);
             }
         },
         {
@@ -125,10 +125,10 @@ runSubtagTests({
             expected: '[3,4]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 'a', [1, 2, 'd'], 'e', 'f', 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 'a', [1, 2, 'd'], 'e', 'f', 5, 6]);
             }
         },
         {
@@ -137,10 +137,10 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = [1, 2, 3, 4, 5, 6];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, [1, 2, 3, 4, 5, 6]);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`]).to.deep.equal([1, 2, 'a', [1, 2, 'd'], 'e', 'f', 5, 6]);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' })).to.deep.equal([1, 2, 'a', [1, 2, 'd'], 'e', 'f', 5, 6]);
             }
         },
         {
@@ -155,7 +155,7 @@ runSubtagTests({
             ],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = 'abc';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, 'abc');
             }
         },
         {

--- a/test/bbtag/subtags/bot/commit.test.ts
+++ b/test/bbtag/subtags/bot/commit.test.ts
@@ -15,10 +15,10 @@ runSubtagTests({
             setup(ctx) {
                 ctx.options.rootTagName = 'commitTest';
 
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var1: 5, var2: 'abc' }), argument.isDeepEqual({ type: TagVariableType.LOCAL, name: 'commitTest' }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var1: 5, var2: 'abc' }), argument.isDeepEqual({ type: TagVariableType.LOCAL_TAG, name: 'commitTest' }))).thenResolve(undefined);
                 ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var5: 5, var6: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GLOBAL }))).thenResolve(undefined);
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var7: 5, var8: 'abc' }), argument.isDeepEqual({ type: TagVariableType.AUTHOR, entityId: ctx.users.command.id }))).thenResolve(undefined);
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var9: 5, var10: 'abc' }), argument.isDeepEqual({ type: TagVariableType.TAGGUILD, entityId: ctx.guild.id }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var7: 5, var8: 'abc' }), argument.isDeepEqual({ type: TagVariableType.AUTHOR, authorId: ctx.users.command.id }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var9: 5, var10: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }))).thenResolve(undefined);
             },
             async postSetup(bbctx) {
                 await bbctx.variables.set('var1', 5);
@@ -41,10 +41,10 @@ runSubtagTests({
                 ctx.options.rootTagName = 'commitTest';
                 ctx.options.isCC = true;
 
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var1: 5, var2: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GUILDLOCAL, entityId: ctx.guild.id, name: 'commitTest' }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var1: 5, var2: 'abc' }), argument.isDeepEqual({ type: TagVariableType.LOCAL_CC, guildId: ctx.guild.id, name: 'commitTest' }))).thenResolve(undefined);
                 ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var5: 5, var6: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GLOBAL }))).thenResolve(undefined);
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var7: 5, var8: 'abc' }), argument.isDeepEqual({ type: TagVariableType.AUTHOR, entityId: ctx.users.command.id }))).thenResolve(undefined);
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var9: 5, var10: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GUILD, entityId: ctx.guild.id }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var7: 5, var8: 'abc' }), argument.isDeepEqual({ type: TagVariableType.AUTHOR, authorId: ctx.users.command.id }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var9: 5, var10: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GUILD_CC, guildId: ctx.guild.id }))).thenResolve(undefined);
             },
             async postSetup(bbctx) {
                 await bbctx.variables.set('var1', 5);
@@ -66,10 +66,10 @@ runSubtagTests({
             setup(ctx) {
                 ctx.options.rootTagName = 'commitTest';
 
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var1: 5 }), argument.isDeepEqual({ type: TagVariableType.LOCAL, name: 'commitTest' }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var1: 5 }), argument.isDeepEqual({ type: TagVariableType.LOCAL_TAG, name: 'commitTest' }))).thenResolve(undefined);
                 ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var5: 5 }), argument.isDeepEqual({ type: TagVariableType.GLOBAL }))).thenResolve(undefined);
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var7: 5 }), argument.isDeepEqual({ type: TagVariableType.AUTHOR, entityId: ctx.users.command.id }))).thenResolve(undefined);
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var9: 5 }), argument.isDeepEqual({ type: TagVariableType.TAGGUILD, entityId: ctx.guild.id }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var7: 5 }), argument.isDeepEqual({ type: TagVariableType.AUTHOR, authorId: ctx.users.command.id }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var9: 5 }), argument.isDeepEqual({ type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }))).thenResolve(undefined);
             },
             async postSetup(bbctx) {
                 await bbctx.variables.set('var1', 5);
@@ -92,10 +92,10 @@ runSubtagTests({
                 ctx.options.rootTagName = 'commitTest';
                 ctx.options.isCC = true;
 
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var2: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GUILDLOCAL, entityId: ctx.guild.id, name: 'commitTest' }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var2: 'abc' }), argument.isDeepEqual({ type: TagVariableType.LOCAL_CC, guildId: ctx.guild.id, name: 'commitTest' }))).thenResolve(undefined);
                 ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var6: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GLOBAL }))).thenResolve(undefined);
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var8: 'abc' }), argument.isDeepEqual({ type: TagVariableType.AUTHOR, entityId: ctx.users.command.id }))).thenResolve(undefined);
-                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var10: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GUILD, entityId: ctx.guild.id }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var8: 'abc' }), argument.isDeepEqual({ type: TagVariableType.AUTHOR, authorId: ctx.users.command.id }))).thenResolve(undefined);
+                ctx.tagVariablesTable.setup(m => m.upsert(argument.isDeepEqual({ var10: 'abc' }), argument.isDeepEqual({ type: TagVariableType.GUILD_CC, guildId: ctx.guild.id }))).thenResolve(undefined);
             },
             async postSetup(bbctx) {
                 await bbctx.variables.set('var1', 5);

--- a/test/bbtag/subtags/bot/get.test.ts
+++ b/test/bbtag/subtags/bot/get.test.ts
@@ -9,31 +9,31 @@ runSubtagTests({
     argCountBounds: { min: 1, max: 2 },
     cases: [
         ...generateTestCases(false, 'testTag', [
-            { args: ['myVariableName'], key: `${TagVariableType.LOCAL}.testTag.myVariableName`, value: 'LOCAL_TAG value', expected: 'LOCAL_TAG value' },
+            { args: ['myVariableName'], key: { scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'myVariableName' }, value: 'LOCAL_TAG value', expected: 'LOCAL_TAG value' },
             { args: ['~myVariableName'], key: undefined, value: undefined, expected: '' },
-            { args: ['*myVariableName'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: 'GLOBAL value', expected: 'GLOBAL value' },
-            { args: ['@myVariableName'], key: `${TagVariableType.AUTHOR}.823764823946284623234.myVariableName`, value: 'AUTHOR value', expected: 'AUTHOR value' },
-            { args: ['_myVariableName'], key: `${TagVariableType.TAGGUILD}.23904768237436873424.myVariableName`, value: 'GUILD_TAG value', expected: 'GUILD_TAG value' },
-            { args: ['myVariableName'], key: `${TagVariableType.LOCAL}.testTag.myVariableName`, value: 'LOCAL_TAG value', expected: 'LOCAL_TAG value' },
-            { args: ['*myVariableName'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: ['a', 'b', 'c'], expected: '{"v":["a","b","c"],"n":"*myVariableName"}' },
-            { args: ['*myVariableName', '0'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: ['a', 'b', 'c'], expected: 'a' },
-            { args: ['*myVariableName', '1'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: ['a', 'b', 'c'], expected: 'b' },
-            { args: ['*myVariableName', '2'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: ['a', 'b', 'c'], expected: 'c' },
-            { args: ['*myVariableName', '2'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: 'This isnt an array', expected: 'This isnt an array' },
-            { args: ['*myVariableName', 'abc'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: 'This isnt an array', expected: 'This isnt an array' }
+            { args: ['*myVariableName'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: 'GLOBAL value', expected: 'GLOBAL value' },
+            { args: ['@myVariableName'], key: { scope: { type: TagVariableType.AUTHOR, authorId: '823764823946284623234' }, name: 'myVariableName' }, value: 'AUTHOR value', expected: 'AUTHOR value' },
+            { args: ['_myVariableName'], key: { scope: { type: TagVariableType.GUILD_TAG, guildId: '23904768237436873424' }, name: 'myVariableName' }, value: 'GUILD_TAG value', expected: 'GUILD_TAG value' },
+            { args: ['myVariableName'], key: { scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'myVariableName' }, value: 'LOCAL_TAG value', expected: 'LOCAL_TAG value' },
+            { args: ['*myVariableName'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: ['a', 'b', 'c'], expected: '{"v":["a","b","c"],"n":"*myVariableName"}' },
+            { args: ['*myVariableName', '0'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: ['a', 'b', 'c'], expected: 'a' },
+            { args: ['*myVariableName', '1'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: ['a', 'b', 'c'], expected: 'b' },
+            { args: ['*myVariableName', '2'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: ['a', 'b', 'c'], expected: 'c' },
+            { args: ['*myVariableName', '2'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: 'This isnt an array', expected: 'This isnt an array' },
+            { args: ['*myVariableName', 'abc'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: 'This isnt an array', expected: 'This isnt an array' }
         ]),
         ...generateTestCases(true, 'testTag', [
-            { args: ['myVariableName'], key: `${TagVariableType.GUILDLOCAL}.23904768237436873424_testTag.myVariableName`, value: 'LOCAL_CC value', expected: 'LOCAL_CC value' },
+            { args: ['myVariableName'], key: { scope: { type: TagVariableType.LOCAL_CC, guildId: '23904768237436873424', name: 'testTag' }, name: 'myVariableName' }, value: 'LOCAL_CC value', expected: 'LOCAL_CC value' },
             { args: ['~myVariableName'], key: undefined, value: undefined, expected: '' },
-            { args: ['*myVariableName'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: 'GLOBAL value', expected: 'GLOBAL value' },
-            { args: ['@myVariableName'], key: `${TagVariableType.AUTHOR}.823764823946284623234.myVariableName`, value: 'AUTHOR value', expected: 'AUTHOR value' },
-            { args: ['_myVariableName'], key: `${TagVariableType.GUILD}.23904768237436873424.myVariableName`, value: 'GUILD_CC value', expected: 'GUILD_CC value' },
-            { args: ['*myVariableName'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: ['a', 'b', 'c'], expected: '{"v":["a","b","c"],"n":"*myVariableName"}' },
-            { args: ['*myVariableName', '0'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: ['a', 'b', 'c'], expected: 'a' },
-            { args: ['*myVariableName', '1'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: ['a', 'b', 'c'], expected: 'b' },
-            { args: ['*myVariableName', '2'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: ['a', 'b', 'c'], expected: 'c' },
-            { args: ['*myVariableName', '2'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: 'This isnt an array', expected: 'This isnt an array' },
-            { args: ['*myVariableName', 'abc'], key: `${TagVariableType.GLOBAL}..myVariableName`, value: 'This isnt an array', expected: 'This isnt an array' }
+            { args: ['*myVariableName'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: 'GLOBAL value', expected: 'GLOBAL value' },
+            { args: ['@myVariableName'], key: { scope: { type: TagVariableType.AUTHOR, authorId: '823764823946284623234' }, name: 'myVariableName' }, value: 'AUTHOR value', expected: 'AUTHOR value' },
+            { args: ['_myVariableName'], key: { scope: { type: TagVariableType.GUILD_CC, guildId: '23904768237436873424' }, name: 'myVariableName' }, value: 'GUILD_CC value', expected: 'GUILD_CC value' },
+            { args: ['*myVariableName'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: ['a', 'b', 'c'], expected: '{"v":["a","b","c"],"n":"*myVariableName"}' },
+            { args: ['*myVariableName', '0'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: ['a', 'b', 'c'], expected: 'a' },
+            { args: ['*myVariableName', '1'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: ['a', 'b', 'c'], expected: 'b' },
+            { args: ['*myVariableName', '2'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: ['a', 'b', 'c'], expected: 'c' },
+            { args: ['*myVariableName', '2'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: 'This isnt an array', expected: 'This isnt an array' },
+            { args: ['*myVariableName', 'abc'], key: { scope: { type: TagVariableType.GLOBAL }, name: 'myVariableName' }, value: 'This isnt an array', expected: 'This isnt an array' }
         ]),
         {
             code: '{get;*myVariableName;abc}',
@@ -68,7 +68,7 @@ runSubtagTests({
     ]
 });
 
-function* generateTestCases(isCC: boolean, tagName: string, cases: Array<{ args: string[]; key: keyof SubtagTestContext['tagVariables'] | undefined; value: JToken | undefined; expected: string; }>): Generator<SubtagTestCase> {
+function* generateTestCases(isCC: boolean, tagName: string, cases: Array<{ args: string[]; key: Parameters<SubtagTestContext['tagVariables']['get']>[0] | undefined; value: JToken | undefined; expected: string; }>): Generator<SubtagTestCase> {
     for (const { args, key, value, expected } of cases) {
         const title = isCC ? 'Custom command' : 'Tag';
         const code = `{${['get', ...args].join(';')}}`;
@@ -82,8 +82,12 @@ function* generateTestCases(isCC: boolean, tagName: string, cases: Array<{ args:
                 ctx.users.command.id = '823764823946284623234';
                 ctx.options.isCC = isCC;
                 ctx.options.tagName = tagName;
-                if (key !== undefined)
-                    ctx.tagVariables[key] = value;
+                if (key !== undefined) {
+                    if (value === undefined)
+                        ctx.tagVariables.delete(key);
+                    else
+                        ctx.tagVariables.set(key, value);
+                }
             }
         };
         yield {
@@ -111,8 +115,12 @@ function* generateTestCases(isCC: boolean, tagName: string, cases: Array<{ args:
                 ctx.users.command.id = '823764823946284623234';
                 ctx.options.isCC = isCC;
                 ctx.options.tagName = tagName;
-                if (key !== undefined)
-                    ctx.tagVariables[key] = value;
+                if (key !== undefined) {
+                    if (value === undefined)
+                        ctx.tagVariables.delete(key);
+                    else
+                        ctx.tagVariables.set(key, value);
+                }
             },
             async postSetup(bbctx) {
                 await bbctx.variables.set(args[0], 'FAIL');

--- a/test/bbtag/subtags/bot/rollback.test.ts
+++ b/test/bbtag/subtags/bot/rollback.test.ts
@@ -1,5 +1,6 @@
 import { BBTagContext } from '@blargbot/bbtag';
 import { RollbackSubtag } from '@blargbot/bbtag/subtags/bot/rollback';
+import { TagVariableType } from '@blargbot/domain/models/index';
 import { expect } from 'chai';
 
 import { runSubtagTests } from '../SubtagTestSuite';
@@ -9,14 +10,14 @@ runSubtagTests({
     argCountBounds: { min: 0, max: Infinity },
     setup(ctx) {
         ctx.options.tagName = 'testTag';
-        ctx.tagVariables['LOCAL_TAG.testTag.var1'] = 22;
-        ctx.tagVariables['LOCAL_TAG.testTag.var2'] = 'def';
-        ctx.tagVariables['GLOBAL..var5'] = 22;
-        ctx.tagVariables['GLOBAL..var6'] = 'def';
-        ctx.tagVariables[`AUTHOR.${ctx.users.command.id}.var7`] = 22;
-        ctx.tagVariables[`AUTHOR.${ctx.users.command.id}.var8`] = 'def';
-        ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.var9`] = 22;
-        ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.var10`] = 'def';
+        ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 22);
+        ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var2' }, 'def');
+        ctx.tagVariables.set({ scope: { type: TagVariableType.GLOBAL }, name: 'var5' }, 22);
+        ctx.tagVariables.set({ scope: { type: TagVariableType.GLOBAL }, name: 'var6' }, 'def');
+        ctx.tagVariables.set({ scope: { type: TagVariableType.AUTHOR, authorId: ctx.users.command.id }, name: 'var7' }, 22);
+        ctx.tagVariables.set({ scope: { type: TagVariableType.AUTHOR, authorId: ctx.users.command.id }, name: 'var8' }, 'def');
+        ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'var9' }, 22);
+        ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'var10' }, 'def');
     },
     async postSetup(bbctx) {
         await bbctx.variables.set('var1', 5);

--- a/test/bbtag/subtags/json/jsonClean.test.ts
+++ b/test/bbtag/subtags/json/jsonClean.test.ts
@@ -33,7 +33,7 @@ runSubtagTests({
             expected: '[{"x":{}}]',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['{"x":"{}"}'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['{"x":"{}"}']);
             }
         },
         {
@@ -41,7 +41,7 @@ runSubtagTests({
             expected: '{"a":{"x":{}}}',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.obj1`] = { a: '{"x":"{}"}' };
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'obj1' }, { a: '{"x":"{}"}' });
             }
         },
         {
@@ -49,7 +49,7 @@ runSubtagTests({
             expected: '{"a":{"x":{}}}',
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = '{"a":"{\\"x\\":\\"{}\\"}"}';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, '{"a":"{\\"x\\":\\"{}\\"}"}');
             }
         },
         {

--- a/test/bbtag/subtags/json/jsonGet.test.ts
+++ b/test/bbtag/subtags/json/jsonGet.test.ts
@@ -52,7 +52,7 @@ function* generateTestCases(source: JToken, path: string, expected: string): Ite
         expected: expected,
         setup(ctx) {
             ctx.options.tagName = 'testTag';
-            ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.myJsonVar`] = source;
+            ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'myJsonVar' }, source);
         }
     };
     yield {
@@ -60,7 +60,7 @@ function* generateTestCases(source: JToken, path: string, expected: string): Ite
         expected: typeof source === 'string' ? source : JSON.stringify(source),
         setup(ctx) {
             ctx.options.tagName = 'testTag';
-            ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.myJsonVar`] = source;
+            ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'myJsonVar' }, source);
         }
     };
 }

--- a/test/bbtag/subtags/json/jsonSet.test.ts
+++ b/test/bbtag/subtags/json/jsonSet.test.ts
@@ -78,7 +78,7 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.jsonVar`] = { test: 123, other: JSON.stringify({ myProp: 123 }) };
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'jsonVar' }, { test: 123, other: JSON.stringify({ myProp: 123 }) });
             },
             async assert(bbctx) {
                 expect((await bbctx.variables.get('jsonVar')).value).to.deep.equal({ test: 123, other: { myProp: '10' } });

--- a/test/bbtag/subtags/json/jsonSort.test.ts
+++ b/test/bbtag/subtags/json/jsonSort.test.ts
@@ -26,12 +26,12 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arrayVar`] = [
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arrayVar' }, [
                     { points: 10, name: 'Blargbot' },
                     { points: 3, name: 'UNO' },
                     { points: 6, name: 'Stupid cat' },
                     { points: 12, name: 'Winner' }
-                ];
+                ]);
             },
             async assert(bbctx) {
                 expect((await bbctx.variables.get('arrayVar')).value).to.deep.equal([
@@ -48,12 +48,12 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arrayVar`] = [
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arrayVar' }, [
                     { points: 10, name: 'Blargbot' },
                     { points: 3, name: 'UNO' },
                     { points: 6, name: 'Stupid cat' },
                     { points: 12, name: 'Winner' }
-                ];
+                ]);
             },
             async assert(bbctx) {
                 expect((await bbctx.variables.get('arrayVar')).value).to.deep.equal([
@@ -73,12 +73,12 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arrayVar`] = [
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arrayVar' }, [
                     { points: 10, name: 'Blargbot' },
                     { test: 3, name: 'UNO' },
                     { points: 6, name: 'Stupid cat' },
                     { points: 12, name: 'Winner' }
-                ];
+                ]);
             }
         },
         {
@@ -90,12 +90,12 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arrayVar`] = [
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arrayVar' }, [
                     { points: 10, name: 'Blargbot' },
                     { points: 3, name: 'UNO' },
                     { points: 6, name: 'Stupid cat' },
                     { points: 12, name: 'Winner' }
-                ];
+                ]);
             }
         },
         {
@@ -107,7 +107,7 @@ runSubtagTests({
             setupSaveVariables: false,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.testVar`] = 'xyz';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'testVar' }, 'xyz');
             }
         }
     ]

--- a/test/bbtag/subtags/json/jsonStringify.test.ts
+++ b/test/bbtag/subtags/json/jsonStringify.test.ts
@@ -81,7 +81,7 @@ runSubtagTests({
 }`,
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.myVar`] = { abc: 123, def: { ghi: [1, 2, 3] } };
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'myVar' }, { abc: 123, def: { ghi: [1, 2, 3] } });
             }
         },
         {

--- a/test/bbtag/subtags/loops/for.test.ts
+++ b/test/bbtag/subtags/loops/for.test.ts
@@ -21,14 +21,14 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'for:loops')).verifiable(10).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal('initial');
             }
         },
         {
@@ -37,14 +37,14 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'for:loops')).verifiable(5).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal('initial');
             }
         },
         {
@@ -53,14 +53,14 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'for:loops')).verifiable(10).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal('initial');
             }
         },
         {
@@ -69,14 +69,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new SetSubtag(), new OperatorSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'for:loops')).verifiable(10).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal('initial');
             }
         },
         {
@@ -88,14 +88,14 @@ runSubtagTests({
             subtags: [new SetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'for:loops')).verifiable(1).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal('initial');
             }
         },
         {
@@ -149,7 +149,7 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 let i = 0;
@@ -161,7 +161,7 @@ runSubtagTests({
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal('initial');
             }
         },
         {
@@ -170,14 +170,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IfSubtag(), new ReturnSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'for:loops')).verifiable(6).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal('initial');
                 expect(bbctx.data.state).to.equal(BBTagRuntimeState.ABORT);
             }
         }

--- a/test/bbtag/subtags/loops/forEach.test.ts
+++ b/test/bbtag/subtags/loops/forEach.test.ts
@@ -23,15 +23,15 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'foreach:loops')).verifiable(3).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -40,15 +40,15 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'foreach:loops')).verifiable(3).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -57,15 +57,15 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'foreach:loops')).verifiable(12).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         },
         {
@@ -74,15 +74,15 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IfSubtag(), new ReturnSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.var1`] = 'this is var1';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'var1' }, 'this is var1');
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'foreach:loops')).verifiable(4).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
                 expect(bbctx.data.state).to.equal(BBTagRuntimeState.ABORT);
             }
         },
@@ -95,8 +95,8 @@ runSubtagTests({
             subtags: [new GetSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.arr1`] = ['this', 'is', 'arr1'];
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`] = 'initial';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'arr1' }, ['this', 'is', 'arr1']);
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' }, 'initial');
             },
             postSetup(bbctx, ctx) {
                 let i = 0;
@@ -108,7 +108,7 @@ runSubtagTests({
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('a')).value).to.equal('initial');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.a`]).to.equal('initial');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'a' })).to.equal('initial');
             }
         }
     ]

--- a/test/bbtag/subtags/loops/repeat.test.ts
+++ b/test/bbtag/subtags/loops/repeat.test.ts
@@ -27,14 +27,14 @@ runSubtagTests({
             subtags: [new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'repeat:loops')).verifiable(8).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(8);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(8);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(8);
             }
         },
         {
@@ -57,14 +57,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IfSubtag(), new ReturnSubtag(), new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'repeat:loops')).verifiable(6).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(6);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(6);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(6);
                 expect(bbctx.data.state).to.equal(BBTagRuntimeState.ABORT);
             }
         },
@@ -77,7 +77,7 @@ runSubtagTests({
             subtags: [new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 let i = 0;
@@ -89,7 +89,7 @@ runSubtagTests({
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(4);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(4);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(4);
             }
         }
     ]

--- a/test/bbtag/subtags/loops/while.test.ts
+++ b/test/bbtag/subtags/loops/while.test.ts
@@ -23,14 +23,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IncrementSubtag(), new OperatorSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'while:loops')).verifiable(10).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(10);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(10);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(10);
             }
         },
         {
@@ -39,14 +39,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'while:loops')).verifiable(10).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(10);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(10);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(10);
             }
         },
         {
@@ -55,14 +55,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'while:loops')).verifiable(10).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(10);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(10);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(10);
             }
         },
         {
@@ -71,14 +71,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'while:loops')).verifiable(10).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(10);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(10);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(10);
             }
         },
         {
@@ -87,14 +87,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'while:loops')).verifiable(5).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(10);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(10);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(10);
             }
         },
         {
@@ -103,14 +103,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new DecrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '10';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '10');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'while:loops')).verifiable(10).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(0);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(0);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(0);
             }
         },
         {
@@ -119,14 +119,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new SetSubtag(), new OperatorSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '1';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '1');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'while:loops')).verifiable(10).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal('1024');
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal('1024');
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal('1024');
             }
         },
         {
@@ -138,7 +138,7 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 let i = 0;
@@ -150,7 +150,7 @@ runSubtagTests({
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(4);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(4);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(4);
             }
         },
         {
@@ -162,7 +162,7 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 let i = 0;
@@ -174,7 +174,7 @@ runSubtagTests({
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(4);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(4);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(4);
             }
         },
         {
@@ -186,7 +186,7 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 let i = 0;
@@ -198,7 +198,7 @@ runSubtagTests({
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(4);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(4);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(4);
             }
         },
         {
@@ -207,14 +207,14 @@ runSubtagTests({
             subtags: [new GetSubtag(), new IfSubtag(), new ReturnSubtag(), new IncrementSubtag()],
             setup(ctx) {
                 ctx.options.tagName = 'testTag';
-                ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`] = '0';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' }, '0');
             },
             postSetup(bbctx, ctx) {
                 ctx.limit.setup(m => m.check(bbctx, 'while:loops')).verifiable(6).thenResolve(undefined);
             },
             async assert(bbctx, _, ctx) {
                 expect((await bbctx.variables.get('index')).value).to.equal(6);
-                expect(ctx.tagVariables[`${TagVariableType.LOCAL}.testTag.index`]).to.equal(6);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.LOCAL_TAG, name: 'testTag' }, name: 'index' })).to.equal(6);
                 expect(bbctx.data.state).to.equal(BBTagRuntimeState.ABORT);
             }
         }

--- a/test/bbtag/subtags/math/decrement.test.ts
+++ b/test/bbtag/subtags/math/decrement.test.ts
@@ -1,5 +1,6 @@
 import { NotABooleanError, NotANumberError } from '@blargbot/bbtag/errors';
 import { DecrementSubtag } from '@blargbot/bbtag/subtags/math/decrement';
+import { TagVariableType } from '@blargbot/domain/models/index';
 import { expect } from 'chai';
 
 import { runSubtagTests } from '../SubtagTestSuite';
@@ -12,47 +13,47 @@ runSubtagTests({
             code: '{decrement;_myVariable}',
             expected: '17',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 18;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 18);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(17);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(17);
             }
         },
         {
             code: '{decrement;_myVariable}',
             expected: '17',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 18.1;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 18.1);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(17);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(17);
             }
         },
         {
             code: '{decrement;_myVariable}',
             expected: '17',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 18.9999;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 18.9999);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(17);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(17);
             }
         },
         {
             code: '{decrement;_myVariable}',
             expected: '17',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = '18';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, '18');
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(17);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(17);
             }
         },
         {
             code: '{decrement;_myVariable}',
             expected: '`Not a number`',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 'abc';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 'abc');
                 Object.freeze(ctx.tagVariables);
             },
             errors: [
@@ -63,37 +64,37 @@ runSubtagTests({
             code: '{decrement;_myVariable;3}',
             expected: '19',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(19);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(19);
             }
         },
         {
             code: '{decrement;_myVariable;3}',
             expected: '19',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22.1;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22.1);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(19);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(19);
             }
         },
         {
             code: '{decrement;_myVariable;3.6}',
             expected: '19',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(19);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(19);
             }
         },
         {
             code: '{decrement;_myVariable;xyz}',
             expected: '`Not a number`',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22);
                 Object.freeze(ctx.tagVariables);
             },
             errors: [
@@ -104,67 +105,67 @@ runSubtagTests({
             code: '{decrement;_myVariable;9;true}',
             expected: '7',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(7);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(7);
             }
         },
         {
             code: '{decrement;_myVariable;9;true}',
             expected: '7',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16.1;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16.1);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(7);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(7);
             }
         },
         {
             code: '{decrement;_myVariable;9.6;true}',
             expected: '7',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(7);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(7);
             }
         },
         {
             code: '{decrement;_myVariable;9;false}',
             expected: '7',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(7);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(7);
             }
         },
         {
             code: '{decrement;_myVariable;9;false}',
             expected: '7.100000000000001',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16.1;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16.1);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(7.100000000000001);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(7.100000000000001);
             }
         },
         {
             code: '{decrement;_myVariable;9.6;false}',
             expected: '6.4',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(6.4);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(6.4);
             }
         },
         {
             code: '{decrement;_myVariable;;abc}',
             expected: '`Not a boolean`',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22);
                 Object.freeze(ctx.tagVariables);
             },
             errors: [

--- a/test/bbtag/subtags/math/increment.test.ts
+++ b/test/bbtag/subtags/math/increment.test.ts
@@ -1,5 +1,6 @@
 import { NotABooleanError, NotANumberError } from '@blargbot/bbtag/errors';
 import { IncrementSubtag } from '@blargbot/bbtag/subtags/math/increment';
+import { TagVariableType } from '@blargbot/domain/models/index';
 import { expect } from 'chai';
 
 import { runSubtagTests } from '../SubtagTestSuite';
@@ -12,47 +13,47 @@ runSubtagTests({
             code: '{increment;_myVariable}',
             expected: '19',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 18;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 18);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(19);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(19);
             }
         },
         {
             code: '{increment;_myVariable}',
             expected: '19',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 18.1;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 18.1);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(19);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(19);
             }
         },
         {
             code: '{increment;_myVariable}',
             expected: '19',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 18.9999;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 18.9999);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(19);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(19);
             }
         },
         {
             code: '{increment;_myVariable}',
             expected: '19',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = '18';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, '18');
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(19);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(19);
             }
         },
         {
             code: '{increment;_myVariable}',
             expected: '`Not a number`',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 'abc';
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 'abc');
                 Object.freeze(ctx.tagVariables);
             },
             errors: [
@@ -63,37 +64,37 @@ runSubtagTests({
             code: '{increment;_myVariable;3}',
             expected: '25',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(25);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(25);
             }
         },
         {
             code: '{increment;_myVariable;3}',
             expected: '25',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22.1;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22.1);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(25);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(25);
             }
         },
         {
             code: '{increment;_myVariable;3.6}',
             expected: '25',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(25);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(25);
             }
         },
         {
             code: '{increment;_myVariable;xyz}',
             expected: '`Not a number`',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22);
                 Object.freeze(ctx.tagVariables);
             },
             errors: [
@@ -104,67 +105,67 @@ runSubtagTests({
             code: '{increment;_myVariable;9;true}',
             expected: '25',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(25);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(25);
             }
         },
         {
             code: '{increment;_myVariable;9;true}',
             expected: '25',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16.1;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16.1);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(25);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(25);
             }
         },
         {
             code: '{increment;_myVariable;9.6;true}',
             expected: '25',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(25);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(25);
             }
         },
         {
             code: '{increment;_myVariable;9;false}',
             expected: '25',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(25);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(25);
             }
         },
         {
             code: '{increment;_myVariable;9;false}',
             expected: '25.1',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16.1;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16.1);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(25.1);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(25.1);
             }
         },
         {
             code: '{increment;_myVariable;9.6;false}',
             expected: '25.6',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 16;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 16);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`]).to.equal(25.6);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' })).to.equal(25.6);
             }
         },
         {
             code: '{increment;_myVariable;;abc}',
             expected: '`Not a boolean`',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 22;
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 22);
                 Object.freeze(ctx.tagVariables);
             },
             errors: [

--- a/test/bbtag/subtags/misc/color.test.ts
+++ b/test/bbtag/subtags/misc/color.test.ts
@@ -1,5 +1,6 @@
 import { BBTagRuntimeError } from '@blargbot/bbtag/errors';
 import { ColorFormat, ColorSubtag } from '@blargbot/bbtag/subtags/misc/color';
+import { TagVariableType } from '@blargbot/domain/models/index';
 
 import { MarkerError, runSubtagTests, SubtagTestCase } from '../SubtagTestSuite';
 
@@ -24,7 +25,7 @@ runSubtagTests({
         {
             code: '{color;_myVariable}',
             expected: '`Invalid color`',
-            setup(ctx) { ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = 'abc'; },
+            setup(ctx) { ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, 'abc'); },
             errors: [
                 { start: 0, end: 19, error: new BBTagRuntimeError('Invalid color', '"_myVariable" is not a valid color') }
             ]
@@ -33,7 +34,7 @@ runSubtagTests({
             code: '{color;_myVariable}',
             expected: '204080',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myVariable`] = [32, 64, 128];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myVariable' }, [32, 64, 128]);
             }
         },
         ...generateTestCases('FFFFFF', '', { hex: 'FFFFFF', ansi16: '[97]', ansi256: '[231]', apple: '[65535,65535,65535]', cmyk: '[0,0,0,0]', gray: '100', hcg: '[0,0,100]', hsl: '[0,0,100]', hsv: '[0,0,100]', hwb: '[0,100,0]', keyword: 'white', lab: '[100,0.01,-0.01]', lch: '[100,0.01,296.81]', rgb: '[255,255,255]', xyz: '[95.047,100,108.83]' }),

--- a/test/bbtag/subtags/misc/reverse.test.ts
+++ b/test/bbtag/subtags/misc/reverse.test.ts
@@ -1,5 +1,6 @@
 import { GetSubtag } from '@blargbot/bbtag/subtags/bot/get';
 import { ReverseSubtag } from '@blargbot/bbtag/subtags/misc/reverse';
+import { TagVariableType } from '@blargbot/domain/models/index';
 import { expect } from 'chai';
 
 import { runSubtagTests } from '../SubtagTestSuite';
@@ -14,10 +15,10 @@ runSubtagTests({
             code: '{reverse;_myArray}',
             expected: 'yarrAym_',
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myArray`] = ['abc', 'def', 'ghi'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myArray' }, ['abc', 'def', 'ghi']);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myArray`]).to.deep.equal(['abc', 'def', 'ghi']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myArray' })).to.deep.equal(['abc', 'def', 'ghi']);
             }
         },
         {
@@ -25,10 +26,10 @@ runSubtagTests({
             expected: '',
             subtags: [new GetSubtag()],
             setup(ctx) {
-                ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myArray`] = ['abc', 'def', 'ghi'];
+                ctx.tagVariables.set({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myArray' }, ['abc', 'def', 'ghi']);
             },
             assert(_, __, ctx) {
-                expect(ctx.tagVariables[`GUILD_TAG.${ctx.guild.id}.myArray`]).to.deep.equal(['ghi', 'def', 'abc']);
+                expect(ctx.tagVariables.get({ scope: { type: TagVariableType.GUILD_TAG, guildId: ctx.guild.id }, name: 'myArray' })).to.deep.equal(['ghi', 'def', 'abc']);
             }
         }
     ]

--- a/test/bbtag/subtags/user/userTimezone.test.ts
+++ b/test/bbtag/subtags/user/userTimezone.test.ts
@@ -16,19 +16,19 @@ runSubtagTests({
                 {
                     expected: 'UTC',
                     setup(member, ctx) {
-                        ctx.userTable.setup(m => m.getSetting(member.user.id, 'timezone')).thenResolve(undefined);
+                        ctx.userTable.setup(m => m.getProp(member.user.id, 'timezone')).thenResolve(undefined);
                     }
                 },
                 {
                     expected: 'abc',
                     setup(member, ctx) {
-                        ctx.userTable.setup(m => m.getSetting(member.user.id, 'timezone')).thenResolve('abc');
+                        ctx.userTable.setup(m => m.getProp(member.user.id, 'timezone')).thenResolve('abc');
                     }
                 },
                 {
                     expected: 'Etc/UTC',
                     setup(member, ctx) {
-                        ctx.userTable.setup(m => m.getSetting(member.user.id, 'timezone')).thenResolve('Etc/UTC');
+                        ctx.userTable.setup(m => m.getProp(member.user.id, 'timezone')).thenResolve('Etc/UTC');
                     }
                 }
             ]

--- a/test/cluster/text.test.ts
+++ b/test/cluster/text.test.ts
@@ -2334,13 +2334,36 @@ describe('Cluster format strings', () => {
             },
             bot: {
                 reset: {
-                    description: 'Resets the bot to the state it is in when joining a guild for the first time.',
-                    cancelled: '❌ Reset cancelled',
-                    success: '✅ I have been reset back to my initial configuration',
+                    description: 'Deletes all persistent information that the bot holds. If used in a guild, this includes settings, custom commands and guild variables. If used in a DM this includes user settings, tags and author variables. You can preview exactly what will be deleted by doing `bot dump` first!',
+                    unavailable: 'The bot cannot be reset here',
+                    guild: {
+                        cancelled: '❌ Reset cancelled',
+                        success: '✅ I have been reset back to my initial configuration',
+                        confirm: {
+                            prompt: '⚠️ Are you sure you want to reset the bot to its initial state?\nThis will:\n- Reset all settings back to their defaults\n- Delete all custom commands, autoresponses, rolemes, censors, etc\n- Delete all tag guild variables',
+                            cancel: 'No',
+                            continue: 'Yes'
+                        }
+                    },
+                    user: {
+                        cancelled: '❌ Reset cancelled',
+                        success: '✅ I have been reset back to my initial configuration',
+                        confirm: {
+                            prompt: '⚠️ Are you sure you want to reset the bot to its initial state?\nThis will:\n- Reset all your user settings back to their defaults\n- Delete all tags you have made\n- Delete all author variables',
+                            cancel: 'No',
+                            continue: 'Yes'
+                        }
+                    }
+                },
+                dump: {
+                    description: 'Dumps all persistent information that the bot holds. If used',
+                    unavailable: 'The bot cannot be reset here',
+                    success: '✅ I have attached the data you requested!',
+                    cancelled: '❌ Dump cancelled',
                     confirm: {
-                        prompt: '⚠️ Are you sure you want to reset the bot to its initial state?\nThis will:\n- Reset all settings back to their defaults\n- Delete all custom commands, autoresponses, rolemes, censors, etc\n- Delete all tag guild variables',
-                        cancel: 'No',
-                        continue: 'Yes'
+                        prompt: '⚠️ Are you sure you want to dump all the information blargbot is holding? This could include some sensitive information, so ensure that it is ok for everyone here to see it.',
+                        cancel: 'Cancel',
+                        continue: 'Show me that data'
                     }
                 }
             },


### PR DESCRIPTION
Adds a command to dump all the data blargbot currently holds for a particular context.

If used inside a guild, it dumps all the data stored about that guild
If used inside a DM, it dumps all the data stored on you.

`b!bot dump`

Implements [Any way to list all global variables used upon current guild?](https://discord.com/channels/194232473931087872/1036949097040596992)